### PR TITLE
Added username matching for alternate files

### DIFF
--- a/yadm
+++ b/yadm
@@ -104,10 +104,11 @@ function alt() {
 
   require_repo
 
-  #; regex for matching "<file>##SYSTEM.HOSTNAME"
+  #; regex for matching "<file>##SYSTEM.HOSTNAME.USER"
   match_system=$(uname -s)
   match_host=$(hostname -s)
-  match="^(.+)##($match_system|$match_system.$match_host|())$"
+  match_user=${USER}
+  match="^(.+)##($match_system|$match_system.$match_host|$match_system.$match_host.$match_user|())$"
 
   #; process relative to YADM_WORK
   YADM_WORK=$(git config core.worktree)


### PR DESCRIPTION
I wanted to be able to use yadm with different users on the same system, so I added this little patch for the alternate file functionality. You can now also create alternate files like foo.txt##Linux.host.user