### PR TITLE
Allows passing YADM_WORK and YADM_DIR variables from the environment.

### DIFF
--- a/yadm
+++ b/yadm
@@ -17,8 +17,8 @@
 
 VERSION=1.03
 
-YADM_WORK="$HOME"
-YADM_DIR="$HOME/.yadm"
+[ -z "$YADM_WORK" ] && YADM_WORK="$HOME"
+[ -z "$YADM_DIR" ] && YADM_DIR="$HOME/.yadm"
 
 YADM_REPO="$YADM_DIR/repo.git"
 YADM_CONFIG="$YADM_DIR/config"


### PR DESCRIPTION
I wanted to be able to have multiple yadm repositories, for different paths, on the same computer. This seemed like the most straightforward way to do this.

This way I can create aliases like this:

    alias yadm-private="YADM_DIR=$HOME/.yadm-private yadm"

Now I can have two repositories, one public, one private.