### PR TITLE
#7 Add support for asymmetric encryption

### DIFF
--- a/yadm
+++ b/yadm
@@ -223,7 +223,15 @@ function encrypt() {
 
   #; process relative to YADM_WORK
   YADM_WORK=$(git config core.worktree)
+  GPG_KEY="$(config yadm.gpg-recipient)"
   cd $YADM_WORK
+
+  #; Build gpg options for gpg
+  if [ "$GPG_KEY" != "" ]; then
+    GPG_OPTS="-er $GPG_KEY"
+  else
+    GPG_OPTS="-c"
+  fi
 
   #; build a list of globs from YADM_ENCRYPT
   GLOBS=()
@@ -234,7 +242,7 @@ function encrypt() {
   done < "$YADM_ENCRYPT"
 
   #; encrypt all files which match the globs
-  tar -cv ${GLOBS[@]} | gpg --yes -c --output "$YADM_ARCHIVE"
+  tar -cv ${GLOBS[@]} | gpg --yes "$GPG_OPTS" --output "$YADM_ARCHIVE"
   if [ $? = 0 ]; then
     echo "Wrote new file: $YADM_ARCHIVE"
   else

--- a/yadm.1
+++ b/yadm.1
@@ -248,6 +248,12 @@ This feature is enabled by default.
 Disable the permission changes to
 .IR $HOME/.gnupg/* .
 This feature is enabled by default.
+.TP
+.B yadm.gpg-recipient
+Asymmetrically encrypt files with a gpg public/private key pair.
+Provide a key ID to encrypt against that public key.
+If left blank or not provided, symmetric encryption is used instead.
+This feature is disabled by deafult.
 .SH ALTERNATES
 When managing a set of files across different systems, it can be useful to have
 an automated way of choosing an alternate version of a file for a different

--- a/yadm.md
+++ b/yadm.md
@@ -150,6 +150,12 @@
               Disable the permission changes to $HOME/.gnupg/*.  This  feature
               is enabled by default.
 
+       yadm.gpg-recipient
+              Asymmetrically encrypt files with a gpg public/private key pair.
+              Provice a key ID to encrypt against that public key.
+              If left blank or not provided, symmetric encryption is used
+              instead. This feature is disabled by deafult.
+
 ## ALTERNATES
        When managing a set of files across different systems, it can be useful
        to have an automated way of choosing an alternate version of a file for


### PR DESCRIPTION
I had some free time and added the assymetric encryption feature myself. Have a look

* Adds the `yadm.gpg-recipient` option
  * When set, the `yadm.gpg-recipient` option encrypts the archives with this recipient
  * `gpg` is smart enough to figure out how the archive is encrypted when decrypting it - no change required there

Closes #7 