### PR TITLE
Make yadm exit with the return value of git.

### DIFF
--- a/yadm
+++ b/yadm
@@ -86,13 +86,14 @@ function main() {
   else
     #; any other commands are simply passed through to git
     git_command "$@"
+    local git_retval="$?"
   fi
 
   #; process automatic events
   auto_alt
   auto_perms
 
-  exit 0
+  exit $git_retval
 
 }
 
@@ -299,9 +300,10 @@ function git_command() {
 
   #; pass commands through to git
   git "$@"
+  local git_retval="$?"
 
   CHANGES_POSSIBLE=1
-
+  return $git_retval
 }
 
 function help() {


### PR DESCRIPTION
Hi,

I noticed that yadm doesn't exit with the return value of git. This is inconvenient, as git might fail for whatever reason (no repo, no access to repo, etc). Here's a pull request to fix this. It works, at least in my case. Maybe I didn't cover all the exit points of the program, but you get the general idea.

PS: I only noticed this because I was running yadm through a cronjob via the handy [shush](http://web.taranis.org/shush/) wrapper. I made the cronjob fail (intentionally), but I didn't get a mail about the failure, which was odd. Went looking, and this was the reason for it.