### PR TITLE
Fixed yadm-alt to work even if whitespaces exist in filepath

### DIFF
--- a/yadm
+++ b/yadm
@@ -120,8 +120,11 @@ function alt() {
 
   #; loop over all "tracked" files
   #; for every file which matches the above regex, create a symlink
+  BKIFS=$IFS
+  IFS=$'\n'
+  tracked_files=$(git ls-files | sort)
   last_linked=''
-  for tracked_file in $(git ls-files | sort); do
+  for tracked_file in ${tracked_files[@]}; do
     tracked_file="$YADM_WORK/$tracked_file"
     #; process both the path, and it's parent directory
     for alt_path in "$tracked_file" "${tracked_file%/*}"; do
@@ -138,6 +141,7 @@ function alt() {
       fi
     done
   done
+  IFS=$BKIFS
 
 }
 


### PR DESCRIPTION
`yadm alt` did not work if there was whitespace in the file path.

In macOS, A configuration file is often placed in `~/Library/Application \Support/`.
By this fixes, to work even if whitespaces exists in the file path although it is not an elegant.

```
$ yadm alt
Linking ~/.config/git/config.local##Darwin to ~/.config/git/config.local
Linking ~/Library/Application Support/pip/pip.conf##Darwin to ~/Library/Application Support/pip/pip.conf    # <=
```