### PR TITLE
Fix OS typo in docs

### DIFF
--- a/yadm.1
+++ b/yadm.1
@@ -50,7 +50,7 @@ using a shared Git repository.
 In addition,
 .B yadm
 provides a feature to select alternate versions of files
-based on the operation system or host name.
+based on the operating system or host name.
 Lastly,
 .B yadm
 supplies the ability to manage a subset of secure files, which are
@@ -308,7 +308,7 @@ By default, the first "gpg" found in $PATH is used.
 .SH ALTERNATES
 When managing a set of files across different systems, it can be useful to have
 an automated way of choosing an alternate version of a file for a different
-operation system, host, or user.
+operating system, host, or user.
 .B yadm
 implements a feature which will automatically create a symbolic link to
 the appropriate version of a file, as long as you follow a specific naming

--- a/yadm.md
+++ b/yadm.md
@@ -30,7 +30,7 @@
 ## DESCRIPTION
        yadm  is a tool for managing a collection of files across multiple com-
        puters, using a shared Git repository.  In addition,  yadm  provides  a
-       feature  to  select  alternate versions of files based on the operation
+       feature  to  select  alternate versions of files based on the operating
        system or host name.  Lastly, yadm supplies the  ability  to  manage  a
        subset of secure files, which are encrypted before they are included in
        the repository.
@@ -195,7 +195,7 @@
 ## ALTERNATES
        When managing a set of files across different systems, it can be useful
        to have an automated way of choosing an alternate version of a file for
-       a different operation system, host, or user.  yadm implements a feature
+       a different operating system, host, or user.  yadm implements a feature
        which will automatically create a symbolic link to the appropriate ver-
        sion  of  a  file,  as long as you follow a specific naming convention.
        yadm can detect files with names ending in:


### PR DESCRIPTION
Replace *operation* system with *operating* system in man page.