### PR TITLE
Add `enter` function for easier interaction with git repo.

### DIFF
--- a/yadm
+++ b/yadm
@@ -53,7 +53,7 @@ function main() {
 
   #; parse command line arguments
   local retval=0
-  internal_commands="^(alt|bootstrap|clean|clone|config|decrypt|encrypt|help|init|list|perms|version)$"
+  internal_commands="^(alt|bootstrap|clean|clone|config|decrypt|encrypt|enter|help|init|list|perms|version)$"
   if [ -z "$*" ] ; then
     #; no argumnts will result in help()
     help
@@ -406,6 +406,13 @@ function encrypt() {
 
   CHANGES_POSSIBLE=1
 
+}
+
+function enter() {
+    require_repo
+    echo "Entering repo"
+    $SHELL
+    echo "Leaving repo"
 }
 
 function git_command() {

--- a/yadm.1
+++ b/yadm.1
@@ -41,6 +41,8 @@ list
 
 .BR yadm " encrypt
 
+.BR yadm " enter
+
 .BR yadm " decrypt
 .RB [ -l ]
 
@@ -175,6 +177,21 @@ option will list the files stored without extracting them.
 Encrypt all files matching the patterns found in
 .IR $HOME/.yadm/encrypt .
 See the ENCRYPTION section for more details.
+.TP
+.B enter
+Run a subshell with all git variables set. This can be used to easily
+interact with your git repository. This is also useful if you are using
+Emacs Tramp and magit to manage your directory. You can add this
+configuration in your emacs configuration:
+
+.RS
+    (add-to-list 'tramp-methods
+  	     '("yadm"
+  	       (tramp-login-program "yadm")
+  	       (tramp-login-args (("enter")))
+  	       (tramp-remote-shell "/bin/sh")
+  	       (tramp-remote-shell-args ("-c"))))
+.RE
 .TP
 .B gitconfig
 Pass options to the


### PR DESCRIPTION
Run a subshell with all git variables set. This can be used to easily
interact with your git repository. This is also useful if you are using
Emacs Tramp and magit to manage your directory.

Signed-off-by: Sébastien Gross <seb•ɑƬ•chezwam•ɖɵʈ•org>