### PR TITLE
fix for getting 'COMP_WORDS bad array subscript' on completing yadm

### DIFF
--- a/completion/yadm.bash_completion
+++ b/completion/yadm.bash_completion
@@ -9,8 +9,14 @@ if declare -F _git > /dev/null; then
   _yadm() {
 
     local current=${COMP_WORDS[COMP_CWORD]}
-    local penultimate=${COMP_WORDS[COMP_CWORD-1]}
-    local antepenultimate=${COMP_WORDS[COMP_CWORD-2]}
+    local penultimate
+    if (($COMP_WORDS > 0)); then
+      penultimate=${COMP_WORDS[COMP_CWORD-1]}
+    fi
+    local antepenultimate
+    if (($COMP_WORDS > 1)); then
+      antepenultimate=${COMP_WORDS[COMP_CWORD-2]}
+    fi
 
     local GIT_DIR
     # shellcheck disable=SC2034


### PR DESCRIPTION
I stared getting these errors when pressing tab after `yadm `. This seems to be due to `COMP_CWORD` being negative, so this is the fix I applied