### PR TITLE
Add Mingw/Msys support

### DIFF
--- a/yadm
+++ b/yadm
@@ -169,7 +169,7 @@ function alt() {
 
   #; decide if a copy should be done instead of a symbolic link
   local do_copy=0
-  if [[ $OPERATING_SYSTEM =~ (Cygwin|Msys) ]] ; then
+  if [[ $OPERATING_SYSTEM =~ ^(CYGWIN|MSYS) ]] ; then
     if [[ $(config --bool yadm.cygwin-copy) == "true" ]] ; then
       do_copy=1
     fi

--- a/yadm
+++ b/yadm
@@ -169,7 +169,7 @@ function alt() {
 
   #; decide if a copy should be done instead of a symbolic link
   local do_copy=0
-  if [[ $OPERATING_SYSTEM == CYGWIN* ]] ; then
+  if [[ $OPERATING_SYSTEM =~ (Cygwin|Msys) ]] ; then
     if [[ $(config --bool yadm.cygwin-copy) == "true" ]] ; then
       do_copy=1
     fi

--- a/yadm
+++ b/yadm
@@ -809,11 +809,12 @@ function set_operating_system() {
   fi
 
   case "$OPERATING_SYSTEM" in
-    CYGWIN*)
+    CYGWIN*|MINGW*|MSYS*)
       git_version=$(git --version 2>/dev/null)
       if [[ "$git_version" =~ windows ]] ; then
           USE_CYGPATH=1
       fi
+      OPERATING_SYSTEM=$(uname -o)
       ;;
     *)
       ;;


### PR DESCRIPTION
Per https://en.wikipedia.org/wiki/Uname , `uname -s` on [Cygwin](https://cygwin.com/), [MinGW](http://www.mingw.org/), [MinGW-w64](https://sourceforge.net/projects/mingw-w64/), [Msys](http://www.mingw.org/wiki/MSYS), [Msys2](http://www.msys2.org/), [git-bash](https://gitforwindows.org/), etc., return the following values:
````
CYGWIN_NT-5.1
CYGWIN_NT-6.1
CYGWIN_NT-6.1-WOW64
CYGWIN_NT-10.0
MINGW32_NT-6.1
MINGW64_NT-6.1
MSYS_NT-6.1
````
Some people [see](https://github.com/ninenines/erlang.mk/issues/632) `MINGW32_NT-6.2` and `MINGW64_NT-6.2` as well.

This patch replaces `uname -s` with `uname -o` (on these systems only). `uname -o` returns more sane values (again, on these systems only):
```
Cygwin # on all versions of Cygwin
Msys   # on all versions of MinGW32, MinGW64, Msys, Msys2, git-bash, etc.
```
Additionally, `USE_CYGPATH` is set for all Msys variants, as it applies to them too (though I have symlinks working fine in Windows 7).

