### PR TITLE
Don't encrypt nothingness

### DIFF
--- a/yadm
+++ b/yadm
@@ -418,6 +418,11 @@ function encrypt() {
   require_encrypt
   parse_encrypt
 
+  if [ "${#ENCRYPT_INCLUDE_FILES[@]}" -eq 0 ]; then
+    error_out "No files were found to encrypt"
+    return
+  fi
+
   cd_work "Encryption" || return
 
   #; Build gpg options for gpg


### PR DESCRIPTION
Without this patch, users will see the following if their `.yadm/encrypt` file doesn't match any files:
````
$ yadm encrypt
Encrypting the following files:


tar: Cowardly refusing to create an empty archive
Try 'tar --help' or 'tar --usage' for more information.
````
