### PR TITLE
Allow for more complex Jinja templates

### DIFF
--- a/yadm
+++ b/yadm
@@ -223,7 +223,7 @@ function alt() {
           YADM_HOSTNAME="$local_host" \
           YADM_USER="$local_user" \
           YADM_DISTRO=$(query_distro) \
-          "$ENVTPL_PROGRAM" < "$tracked_file" > "$real_file"
+          "$ENVTPL_PROGRAM" --keep-template "$tracked_file" -o "$real_file"
         else
           debug "envtpl not available, not creating $real_file from template $tracked_file"
           [ -n "$loud" ] && echo "envtpl not available, not creating $real_file from template $tracked_file"


### PR DESCRIPTION
By calling envtpl with a filename, Jinja can perform includes, which is useful for more general machine configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thelocehiliosan/yadm/114)
<!-- Reviewable:end -->
