### PR TITLE
Fix bug when using tramp to access yadm

### DIFF
--- a/yadm.1
+++ b/yadm.1
@@ -194,9 +194,12 @@ Emacs Tramp and Magit can manage files by using this configuration:
          '("yadm"
            (tramp-login-program "yadm")
            (tramp-login-args (("enter")))
+           (tramp-login-env (("SHELL") ("/bin/sh")))
            (tramp-remote-shell "/bin/sh")
            (tramp-remote-shell-args ("-c"))))
 .RE
+and use (magit-status "/yadm::"). If you find issue with Emacs 27 and zsh,
+trying running (setenv "SHELL" "/bin/bash").
 .TP
 .B gitconfig
 Pass options to the


### PR DESCRIPTION
yadm casus tramp to hang when called. According to emacs-wiki
https://www.emacswiki.org/emacs/TrampMode#toc9, this can be fixed by feeding
tramp a shell with bare PS1.