### PR TITLE
Initial support for alternative cyphers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ language: minimal
 services:
   - docker
 before_install:
-  - docker pull yadm/testbed:2019-12-02
+  - docker pull yadm/testbed:2020-01-20
 script:
-  - docker run -t --rm -v "$PWD:/yadm:ro" yadm/testbed:2019-12-02
+  - docker run -t --rm -v "$PWD:/yadm:ro" yadm/testbed:2020-01-20

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,12 @@
+2.4.0
+  * Support multiple keys in `yadm.gpg-recipient` (#139)
+  * Ensure all templates are written atomically (#142)
+  * Add encrypt_with_checksums to the hooks collection (#188)
+  * Escape white space in YADM_HOOK_FULL_COMMAND (#187)
+  * Improve parsing of os-release (#194)
+  * Improve identification of WSL (#196)
+  * Fix troff warnings emitted by man page (#195)
+  * Write encrypt-based exclusions during decrypt
 2.3.0
   * Support git-crypt (#168)
   * Support specifying a command after `yadm enter`

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,25 +1,29 @@
 CONTRIBUTORS
 
 Tim Byrne
-Espen Henriksen
+Martin Zuther
 Ross Smith II
+Espen Henriksen
 Cameron Eagans
 Klas Mellbourn
 David Mandelberg
 Daniel Gray
 Jan Schulz
 Siôn Le Roux
+Stig Palmquist
 Sébastien Gross
 Thomas Luzat
 Tomas Cernaj
 Uroš Golja
 con-f-use
-Brayden Banks
 japm48
+Brayden Banks
+jonasc
 Daniel Wagenknecht
 Franciszek Madej
 Mateusz Piotrowski
 Paraplegic Racehorse
 Patrick Hof
+Russ Allbery
 Satoshi Ohki
 Sheng Yang

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN \
     gnupg \
     lsb-release \
     make \
+    man \
     python3-pip \
     shellcheck=0.4.6-1 \
     vim \

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ scripthost: require-docker
 testenv:
 	@echo 'Creating a local virtual environment in "testenv/"'
 	@echo
-	virtualenv --python=python3 testenv
+	python3 -m venv --clear testenv
 	testenv/bin/pip3 install --upgrade pip setuptools
 	testenv/bin/pip3 install --upgrade \
 		flake8==3.7.8 \

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ testhost: require-docker
 		--hostname testhost \
 		--rm -it \
 		-v "/tmp/testhost:/bin/yadm:ro" \
-		yadm/testbed:2019-12-02 \
+		yadm/testbed:2020-01-20 \
 		bash -l
 
 .PHONY: scripthost
@@ -129,7 +129,7 @@ scripthost: require-docker
 		--rm -it \
 		-v "$$PWD/script.gz:/script.gz:rw" \
 		-v "/tmp/testhost:/bin/yadm:ro" \
-		yadm/testbed:2019-12-02 \
+		yadm/testbed:2020-01-20 \
 		bash -c "script /tmp/script -q -c 'bash -l'; gzip < /tmp/script > /script.gz"
 	@echo
 	@echo "Script saved to $$PWD/script.gz"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Features, usage, examples and installation instructions can be found on the
 [master-badge]: https://img.shields.io/travis/TheLocehiliosan/yadm/master.svg?label=master
 [master-commits]: https://github.com/TheLocehiliosan/yadm/commits/master
 [master-date]: https://img.shields.io/github/last-commit/TheLocehiliosan/yadm/master.svg?label=master
-[obs-badge]: https://img.shields.io/badge/OBS-v2.3.0-blue
+[obs-badge]: https://img.shields.io/badge/OBS-v2.4.0-blue
 [obs-link]: https://software.opensuse.org//download.html?project=home%3ATheLocehiliosan%3Ayadm&package=yadm
 [releases-badge]: https://img.shields.io/github/tag/TheLocehiliosan/yadm.svg?label=latest+release
 [releases-link]: https://github.com/TheLocehiliosan/yadm/releases

--- a/contrib/hooks/encrypt_with_checksums/post_encrypt
+++ b/contrib/hooks/encrypt_with_checksums/post_encrypt
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # yadm - Yet Another Dotfiles Manager
-# Copyright (C) 2015-2019 Tim Byrne and Martin Zuther
+# Copyright (C) 2015-2020 Tim Byrne and Martin Zuther
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/contrib/hooks/encrypt_with_checksums/post_list
+++ b/contrib/hooks/encrypt_with_checksums/post_list
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # yadm - Yet Another Dotfiles Manager
-# Copyright (C) 2015-2019 Tim Byrne and Martin Zuther
+# Copyright (C) 2015-2020 Tim Byrne and Martin Zuther
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/contrib/hooks/encrypt_with_checksums/post_status
+++ b/contrib/hooks/encrypt_with_checksums/post_status
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # yadm - Yet Another Dotfiles Manager
-# Copyright (C) 2015-2019 Tim Byrne and Martin Zuther
+# Copyright (C) 2015-2020 Tim Byrne and Martin Zuther
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/contrib/hooks/parsing_full_command_example/README.md
+++ b/contrib/hooks/parsing_full_command_example/README.md
@@ -1,0 +1,7 @@
+## Example of parsing `$YADM_HOOK_FULL_COMMAND`
+
+Contributed by Tim Byrne
+
+Hook    | Description
+----    | -----------
+pre_log | Provides an example of parsing `$YADM_HOOK_FULL_COMMAND` in Bash

--- a/contrib/hooks/parsing_full_command_example/pre_log
+++ b/contrib/hooks/parsing_full_command_example/pre_log
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# yadm exposes all parameters of the command which triggers a hook. Those
+# parameters are exported as the environment variable YADM_HOOK_FULL_COMMAND.
+# Any spaces, tabs, or backslashes in those parameters are escaped with a
+# backslash. The function `parse_full_command()` is a demonstration of parsing
+# those values which may be escaped.
+
+function parse_full_command() {
+  local delim=$'\x1e' # ASCII Record Separator
+  local space=$'\x1f' # ASCII Unit Separator
+  local tab=$'\t'     # ASCII TAB
+  local cmd
+  cmd="$YADM_HOOK_FULL_COMMAND"
+  cmd="${cmd//\\ /$space}"      # swap escaped spaces for `1f`
+  cmd="${cmd//\\\\/\\}"         # fix escaped backslashes
+  cmd="${cmd//\\$tab/$tab}"     # fix escaped tabs
+  cmd="${cmd// /$delim}"        # convert space delimiters to `1c`
+  cmd="${cmd//$space/ }"        # convert `1f` back to spaces
+  # parse data into an array
+  IFS=$delim read -r -a full_cmd <<< "$cmd"
+}
+parse_full_command
+for param in "${full_cmd[@]}"; do
+  echo "Parameter: '$param'"
+done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,4 +4,4 @@ services:
   testbed:
     volumes:
       - .:/yadm:ro
-    image: yadm/testbed:2019-12-02
+    image: yadm/testbed:2020-01-20

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -117,10 +117,13 @@ def supported_configs():
         'yadm.auto-exclude',
         'yadm.auto-perms',
         'yadm.auto-private-dirs',
+        'yadm.cipher',
         'yadm.git-program',
         'yadm.gpg-perms',
         'yadm.gpg-program',
         'yadm.gpg-recipient',
+        'yadm.openssl-ciphername',
+        'yadm.openssl-program',
         'yadm.ssh-perms',
         ]
 

--- a/test/test_syntax.py
+++ b/test/test_syntax.py
@@ -54,3 +54,12 @@ def test_yamllint(pytestconfig, runner, yamllint_version):
         command=['yamllint', '-s', '$(find . -name \\*.yml)'],
         shell=True)
     assert run.success
+
+
+def test_man(runner):
+    """Check for warnings from man"""
+    run = runner(
+        command=['man', '--warnings', './yadm.1'])
+    assert run.success
+    assert run.err == ''
+    assert 'yadm - Yet Another Dotfiles Manager' in run.out

--- a/test/test_unit_set_os.py
+++ b/test/test_unit_set_os.py
@@ -6,12 +6,14 @@ import pytest
 @pytest.mark.parametrize(
     'proc_value, expected_os', [
         ('missing', 'uname'),
-        ('has MiCrOsOfT inside', 'WSL'),  # case insensitive
+        ('has microsoft inside', 'WSL'),  # case insensitive
+        ('has Microsoft inside', 'WSL'),  # case insensitive
         ('another value', 'uname'),
     ], ids=[
         '/proc/version missing',
-        '/proc/version includes MS',
-        '/proc/version excludes MS',
+        '/proc/version includes ms',
+        '/proc/version excludes Ms',
+        'another value',
     ])
 def test_set_operating_system(
         runner, paths, tst_sys, proc_value, expected_os):

--- a/yadm
+++ b/yadm
@@ -1535,7 +1535,9 @@ function configure_repo() {
 
 function set_operating_system() {
 
-  if [[ "$(<"$PROC_VERSION")" =~ [Mm]icrosoft ]]; then
+  local proc_version
+  proc_version=$(cat "$PROC_VERSION" 2>/dev/null)
+  if [[ "$proc_version" =~ [Mm]icrosoft ]]; then
     OPERATING_SYSTEM="WSL"
   else
     OPERATING_SYSTEM=$(uname -s)

--- a/yadm
+++ b/yadm
@@ -1,6 +1,6 @@
 #!/bin/sh
 # yadm - Yet Another Dotfiles Manager
-# Copyright (C) 2015-2019 Tim Byrne
+# Copyright (C) 2015-2020 Tim Byrne
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,7 +20,7 @@ if [ -z "$BASH_VERSION" ]; then
   [ "$YADM_TEST" != 1 ] && exec bash "$0" "$@"
 fi
 
-VERSION=2.3.0
+VERSION=2.4.0
 
 YADM_WORK="$HOME"
 YADM_DIR=

--- a/yadm
+++ b/yadm
@@ -1170,11 +1170,8 @@ yadm.auto-alt
 yadm.auto-exclude
 yadm.auto-perms
 yadm.auto-private-dirs
-<<<<<<< HEAD
-=======
 yadm.cygwin-copy
 yadm.cypher
->>>>>>> local
 yadm.git-program
 yadm.gpg-perms
 yadm.gpg-program

--- a/yadm
+++ b/yadm
@@ -70,7 +70,16 @@ function main() {
   require_git
 
   # capture full command, for passing to hooks
-  FULL_COMMAND="$*"
+  # the parameters will be space delimited and
+  # spaces, tabs, and backslashes will be escaped
+  _tab=$'\t'
+  for param in "$@"; do
+    param="${param//\\/\\\\}"
+    param="${param//$_tab/\\$_tab}"
+    param="${param// /\\ }"
+    _fc+=( "$param" )
+  done
+  FULL_COMMAND="${_fc[*]}"
 
   # create the YADM_DIR if it doesn't exist yet
   [ -d "$YADM_DIR" ] || mkdir -p "$YADM_DIR"

--- a/yadm
+++ b/yadm
@@ -1535,17 +1535,7 @@ function configure_repo() {
 
 function set_operating_system() {
 
-  # setting nocasematch to ignore case
-  local unset_nocasematch
-  if ! shopt nocasematch &> /dev/null; then
-    unset_nocasematch=1
-  fi
-  shopt -s nocasematch &> /dev/null
-
-  # special detection of WSL (windows subsystem for linux)
-  local proc_version
-  proc_version=$(cat "$PROC_VERSION" 2>/dev/null)
-  if [[ "$proc_version" =~ Microsoft ]]; then
+  if [[ "$(<"$PROC_VERSION")" =~ [Mm]icrosoft ]]; then
     OPERATING_SYSTEM="WSL"
   else
     OPERATING_SYSTEM=$(uname -s)
@@ -1562,10 +1552,6 @@ function set_operating_system() {
     *)
       ;;
   esac
-
-  if [ "$unset_nocasematch" = "1" ]; then
-    shopt -u nocasematch &> /dev/null
-  fi
 
 }
 

--- a/yadm
+++ b/yadm
@@ -870,13 +870,13 @@ function _decrypt_from() {
   local output_archive
   output_archive="$1"
 
-  local yadm_crypher
-  yadm_crypher="$(config yadm.cypher)"
-  if [ -z "$yadm_crypher" ]; then
-      yadm_crypher="gpg"
+  local yadm_cipher
+  yadm_cipher="$(config yadm.cipher)"
+  if [ -z "$yadm_cipher" ]; then
+      yadm_cipher="gpg"
   fi
 
-  case "$yadm_crypher" in
+  case "$yadm_cipher" in
     gpg)
       require_gpg
 
@@ -887,11 +887,11 @@ function _decrypt_from() {
       require_openssl
 
       OPENSSL_CIPHERNAME="$(_get_openssl_ciphername)"
-      $OPENSSL_PROGRAM enc -d -$OPENSSL_CIPHERNAME -salt -in "$output_archive"
+      $OPENSSL_PROGRAM enc -d "-${OPENSSL_CIPHERNAME}" -salt -in "$output_archive"
       ;;
 
     *)
-      error_out "Unknown cypher '$yadm_crypher'"
+      error_out "Unknown cipher '$yadm_cipher'"
       ;;
 
   esac
@@ -903,13 +903,13 @@ function _encrypt_to() {
   local output_archive
   output_archive="$1"
 
-  local yadm_crypher
-  yadm_crypher="$(config yadm.cypher)"
-  if [ -z "$yadm_crypher" ]; then
-      yadm_crypher="gpg"
+  local yadm_cipher
+  yadm_cipher="$(config yadm.cipher)"
+  if [ -z "$yadm_cipher" ]; then
+      yadm_cipher="gpg"
   fi
 
-  case "$yadm_crypher" in
+  case "$yadm_cipher" in
     gpg)
       require_gpg
 
@@ -930,11 +930,11 @@ function _encrypt_to() {
       require_openssl
 
       OPENSSL_CIPHERNAME="$(_get_openssl_ciphername)"
-      $OPENSSL_PROGRAM enc -e -$OPENSSL_CIPHERNAME -salt -out "$output_archive"
+      $OPENSSL_PROGRAM enc -e "-${OPENSSL_CIPHERNAME}" -salt -out "$output_archive"
       ;;
 
     *)
-      error_out "Unknown cypher '$yadm_crypher'"
+      error_out "Unknown cipher '$yadm_cipher'"
       ;;
 
   esac
@@ -1171,7 +1171,7 @@ yadm.auto-exclude
 yadm.auto-perms
 yadm.auto-private-dirs
 yadm.cygwin-copy
-yadm.cypher
+yadm.cipher
 yadm.git-program
 yadm.gpg-perms
 yadm.gpg-program

--- a/yadm
+++ b/yadm
@@ -860,6 +860,8 @@ function decrypt() {
   require_gpg
   require_archive
 
+  [ -f "$YADM_ENCRYPT" ] && exclude_encrypted
+
   if [ "$DO_LIST" = "YES" ] ; then
     tar_option="t"
   else

--- a/yadm.1
+++ b/yadm.1
@@ -850,7 +850,8 @@ The command which triggered the hook
 The exit status of the yadm command
 .TP
 .B YADM_HOOK_FULL_COMMAND
-The yadm command with all command line arguments
+The yadm command with all command line arguments (parameters are space
+delimited, and any space, tab or backslash will be escaped with a backslash)
 .TP
 .B YADM_HOOK_REPO
 The path to the yadm repository

--- a/yadm.1
+++ b/yadm.1
@@ -1,5 +1,5 @@
 .\" vim: set spell so=8:
-.TH yadm 1 "17 December 2019" "2.3.0"
+.TH yadm 1 "6 February 2020" "2.4.0"
 
 .SH NAME
 

--- a/yadm.md
+++ b/yadm.md
@@ -314,26 +314,27 @@
        yadm.gpg-recipient
               Asymmetrically encrypt files with a gpg public/private key pair.
               Provide a "key ID" to specify which public key to encrypt  with.
-              The  key  must  exist in your public keyrings.  If left blank or
-              not provided, symmetric encryption is used instead.  If  set  to
-              "ASK",  gpg  will  interactively  ask  for  recipients.  See the
-              ENCRYPTION section for more details.  This feature  is  disabled
+              The key must exist in your public keyrings.  Multiple recipients
+              can be specified (separated by space).  If  left  blank  or  not
+              provided,  symmetric  encryption  is  used  instead.   If set to
+              "ASK", gpg will  interactively  ask  for  recipients.   See  the
+              ENCRYPTION  section  for more details.  This feature is disabled
               by default.
 
        yadm.ssh-perms
               Disable the permission changes to $HOME/.ssh/*.  This feature is
               enabled by default.
 
-       The following  four  "local"  configurations  are  not  stored  in  the
+       The  following  four  "local"  configurations  are  not  stored  in the
        $HOME/.config/yadm/config, they are stored in the local repository.
 
 
        local.class
-              Specify  a  class for the purpose of symlinking alternate files.
+              Specify a class for the purpose of symlinking  alternate  files.
               By default, no class will be matched.
 
        local.hostname
-              Override the hostname for the purpose  of  symlinking  alternate
+              Override  the  hostname  for the purpose of symlinking alternate
               files.
 
        local.os
@@ -348,9 +349,9 @@
        to have an automated way of choosing an alternate version of a file for
        a different operating system, host, user, etc.
 
-       yadm will automatically create a symbolic link to the appropriate  ver-
-       sion  of  a  file, when a valid suffix is appended to the filename. The
-       suffix contains the conditions that must be met for  that  file  to  be
+       yadm  will automatically create a symbolic link to the appropriate ver-
+       sion of a file, when a valid suffix is appended to  the  filename.  The
+       suffix  contains  the  conditions  that must be met for that file to be
        used.
 
        The suffix begins with "##", followed by any number of conditions sepa-
@@ -358,9 +359,9 @@
 
          ##<condition>[,<condition>,...]
 
-       Each condition is an attribute/value pair, separated by a period.  Some
-       conditions  do  not require a "value", and in that case, the period and
-       value can be omitted. Most attributes can be abbreviated  as  a  single
+       Each  condition is an attribute/value pair, separated by a period. Some
+       conditions do not require a "value", and in that case, the  period  and
+       value  can  be  omitted. Most attributes can be abbreviated as a single
        letter.
 
          <attribute>[.<value>]
@@ -370,25 +371,25 @@
 
 
        template, t
-              Valid when the value matches  a  supported  template  processor.
+              Valid  when  the  value  matches a supported template processor.
               See the TEMPLATES section for more details.
 
        user, u
-              Valid  if  the  value matches the current user.  Current user is
+              Valid if the value matches the current user.   Current  user  is
               calculated by running id -u -n.
 
        distro, d
-              Valid if the value matches the distro.  Distro is calculated  by
-              running  lsb_release  -si  or by inspecting the ID from /etc/os-
+              Valid  if the value matches the distro.  Distro is calculated by
+              running lsb_release -si or by inspecting the  ID  from  /etc/os-
               release.
 
-       os, o  Valid if the value matches the OS.  OS is calculated by  running
+       os, o  Valid  if the value matches the OS.  OS is calculated by running
               uname -s.
 
        class, c
               Valid if the value matches the local.class configuration.  Class
               must be manually set using yadm config local.class <class>.  See
-              the   CONFIGURATION  section  for  more  details  about  setting
+              the  CONFIGURATION  section  for  more  details  about   setting
               local.class.
 
        hostname, h
@@ -399,27 +400,27 @@
               Valid when no other alternate is valid.
 
 
-       NOTE:  The  OS  for "Windows Subsystem for Linux" is reported as "WSL",
+       NOTE: The OS for "Windows Subsystem for Linux" is  reported  as  "WSL",
        even though uname identifies as "Linux".
 
-       You may use any number of conditions, in any order.  An alternate  will
-       only  be  used  if  ALL conditions are valid.  For all files managed by
-       yadm's repository or  listed  in  $HOME/.config/yadm/encrypt,  if  they
-       match  this  naming  convention, symbolic links will be created for the
+       You  may use any number of conditions, in any order.  An alternate will
+       only be used if ALL conditions are valid.  For  all  files  managed  by
+       yadm's  repository  or  listed  in  $HOME/.config/yadm/encrypt, if they
+       match this naming convention, symbolic links will be  created  for  the
        most appropriate version.
 
        The "most appropriate" version is determined by calculating a score for
-       each  version  of  a  file. A template is always scored higher than any
-       symlink condition. The number of conditions is the next largest  factor
-       in  scoring.   Files  with  more conditions will always be favored. Any
+       each version of a file. A template is always  scored  higher  than  any
+       symlink  condition. The number of conditions is the next largest factor
+       in scoring.  Files with more conditions will  always  be  favored.  Any
        invalid condition will disqualify that file completely.
 
        If you don't care to have all versions of alternates stored in the same
        directory  as  the  generated  symlink,  you  can  place  them  in  the
-       $HOME/.config/yadm/alt directory. The generated  symlink  or  processed
+       $HOME/.config/yadm/alt  directory.  The  generated symlink or processed
        template will be created using the same relative path.
 
-       Alternate  linking may best be demonstrated by example. Assume the fol-
+       Alternate linking may best be demonstrated by example. Assume the  fol-
        lowing files are managed by yadm's repository:
 
          - $HOME/path/example.txt##default
@@ -442,7 +443,7 @@
 
        $HOME/path/example.txt -> $HOME/path/example.txt##os.Darwin
 
-       Since  the  hostname  doesn't  match any of the managed files, the more
+       Since the hostname doesn't match any of the  managed  files,  the  more
        generic version is chosen.
 
        If running on a Linux server named "host4", the link will be:
@@ -457,57 +458,57 @@
 
        $HOME/path/example.txt -> $HOME/path/example.txt##class.Work
 
-       If no "##default" version exists and no files  have  valid  conditions,
+       If  no  "##default"  version exists and no files have valid conditions,
        then no link will be created.
 
-       Links  are also created for directories named this way, as long as they
+       Links are also created for directories named this way, as long as  they
        have at least one yadm managed file within them.
 
        yadm will automatically create these links by default. This can be dis-
-       abled  using  the yadm.auto-alt configuration.  Even if disabled, links
+       abled using the yadm.auto-alt configuration.  Even if  disabled,  links
        can be manually created by running yadm alt.
 
-       Class is a special value which is stored locally on each  host  (inside
-       the  local repository). To use alternate symlinks using class, you must
-       set the value of class using the configuration  local.class.   This  is
+       Class  is  a special value which is stored locally on each host (inside
+       the local repository). To use alternate symlinks using class, you  must
+       set  the  value  of class using the configuration local.class.  This is
        set like any other yadm configuration with the yadm config command. The
        following sets the class to be "Work".
 
          yadm config local.class Work
 
-       Similarly, the values of os, hostname, and user can be  manually  over-
-       ridden  using  the  configuration options local.os, local.hostname, and
+       Similarly,  the  values of os, hostname, and user can be manually over-
+       ridden using the configuration options  local.os,  local.hostname,  and
        local.user.
 
 
 ## TEMPLATES
-       If a template condition is defined in an alternate file's "##"  suffix,
+       If  a template condition is defined in an alternate file's "##" suffix,
        and the necessary dependencies for the template are available, then the
        file will be processed to create or overwrite files.
 
        Supported template processors:
 
        default
-              This is yadm's built-in template processor.  This  processor  is
+              This  is  yadm's  built-in template processor. This processor is
               very basic, with a Jinja-like syntax. The advantage of this pro-
-              cessor is that it only depends upon awk, which is  available  on
-              most  *nix  systems. To use this processor, specify the value of
+              cessor  is  that it only depends upon awk, which is available on
+              most *nix systems. To use this processor, specify the  value  of
               "default" or just leave the value off (e.g. "##template").
 
-       j2cli  To use the j2cli Jinja template processor, specify the value  of
+       j2cli  To  use the j2cli Jinja template processor, specify the value of
               "j2"  or "j2cli".
 
        envtpl To use the envtpl Jinja template processor, specify the value of
               "j2" or "envtpl".
 
 
-       NOTE: Specifying "j2" as the processor will attempt  to  use  j2cli  or
+       NOTE:  Specifying  "j2"  as  the processor will attempt to use j2cli or
        envtpl, whichever is available.
 
-       If  the  template  processor  specified is available, templates will be
+       If the template processor specified is  available,  templates  will  be
        processed to create or overwrite files.
 
-       During processing, the following variables are available  in  the  tem-
+       During  processing,  the  following variables are available in the tem-
        plate:
 
         Default         Jinja           Description
@@ -519,10 +520,10 @@
         yadm.user       YADM_USER       id -u -n
         yadm.source     YADM_SOURCE     Template filename
 
-       NOTE:  The  OS  for "Windows Subsystem for Linux" is reported as "WSL",
+       NOTE: The OS for "Windows Subsystem for Linux" is  reported  as  "WSL",
        even though uname identifies as "Linux".
 
-       NOTE: If lsb_release is not available, DISTRO will be the ID  specified
+       NOTE:  If lsb_release is not available, DISTRO will be the ID specified
        in /etc/os-release.
 
        Examples:
@@ -535,7 +536,7 @@
          config=dev-whatever
          {% endif %}
 
-       would  output  a  file named whatever with the following content if the
+       would output a file named whatever with the following  content  if  the
        user is "harvey":
 
          config=work-Linux
@@ -544,7 +545,7 @@
 
          config=dev-whatever
 
-       An equivalent Jinja template  named  whatever##template.j2  would  look
+       An  equivalent  Jinja  template  named whatever##template.j2 would look
        like:
 
          {% if YADM_USER == 'harvey' -%}
@@ -555,62 +556,62 @@
 
 
 ## ENCRYPTION
-       It  can  be  useful to manage confidential files, like SSH or GPG keys,
-       across multiple systems. However, doing so would put  plain  text  data
+       It can be useful to manage confidential files, like SSH  or  GPG  keys,
+       across  multiple  systems.  However, doing so would put plain text data
        into a Git repository, which often resides on a public system. yadm can
-       make it easy to encrypt and decrypt a set of  files  so  the  encrypted
-       version  can  be  maintained  in the Git repository.  This feature will
+       make  it  easy  to  encrypt and decrypt a set of files so the encrypted
+       version can be maintained in the Git  repository.   This  feature  will
        only work if the gpg(1) command is available.
 
-       To use this feature, a list of patterns must be created  and  saved  as
-       $HOME/.config/yadm/encrypt.   This  list of patterns should be relative
+       To  use  this  feature, a list of patterns must be created and saved as
+       $HOME/.config/yadm/encrypt.  This list of patterns should  be  relative
        to the configured work-tree (usually $HOME).  For example:
 
                   .ssh/*.key
                   .gnupg/*.gpg
 
        Standard filename expansions (*, ?, [) are supported.  If you have Bash
-       version  4,  you may use "**" to match all subdirectories.  Other shell
+       version 4, you may use "**" to match all subdirectories.   Other  shell
        expansions like brace and tilde are not supported.  Spaces in paths are
-       supported,  and should not be quoted.  If a directory is specified, its
+       supported, and should not be quoted.  If a directory is specified,  its
        contents will be included, but not recursively.  Paths beginning with a
        "!" will be excluded.
 
        The yadm encrypt command will find all files matching the patterns, and
-       prompt for a password. Once a  password  has  confirmed,  the  matching
+       prompt  for  a  password.  Once  a password has confirmed, the matching
        files will be encrypted and saved as $HOME/.config/yadm/files.gpg.  The
-       patterns and files.gpg should be added to the yadm repository  so  they
+       patterns  and  files.gpg should be added to the yadm repository so they
        are available across multiple systems.
 
        To decrypt these files later, or on another system run yadm decrypt and
-       provide the correct password.  After files are  decrypted,  permissions
+       provide  the  correct password.  After files are decrypted, permissions
        are automatically updated as described in the PERMISSIONS section.
 
-       Symmetric  encryption is used by default, but asymmetric encryption may
+       Symmetric encryption is used by default, but asymmetric encryption  may
        be enabled using the yadm.gpg-recipient configuration.
 
-       NOTE: It is recommended that you use a private repository when  keeping
+       NOTE:  It is recommended that you use a private repository when keeping
        confidential files, even though they are encrypted.
 
        Patterns found in $HOME/.config/yadm/encrypt are automatically added to
-       the repository's info/exclude file every  time  yadm  encrypt  is  run.
+       the  repository's  info/exclude  file  every  time yadm encrypt is run.
        This is to prevent accidentally committing sensitive data to the repos-
        itory.  This can be disabled using the yadm.auto-exclude configuration.
 
        Using git-crypt
 
-       A  completely separate option for encrypting data is to install and use
+       A completely separate option for encrypting data is to install and  use
        git-crypt.  Once installed, you can run git-crypt commands for the yadm
-       repo  by running yadm git-crypt.  git-crypt enables transparent encryp-
-       tion and decryption of  files  in  a  git  repository.   You  can  read
+       repo by running yadm git-crypt.  git-crypt enables transparent  encryp-
+       tion  and  decryption  of  files  in  a  git  repository.  You can read
        https://github.com/AGWA/git-crypt for details.
 
 
 
 ## PERMISSIONS
-       When  files  are checked out of a Git repository, their initial permis-
-       sions are dependent upon the user's umask. Because of this,  yadm  will
-       automatically  update  the  permissions of some file paths. The "group"
+       When files are checked out of a Git repository, their  initial  permis-
+       sions  are  dependent upon the user's umask. Because of this, yadm will
+       automatically update the permissions of some file  paths.  The  "group"
        and "others" permissions will be removed from the following files:
 
        - $HOME/.config/yadm/files.gpg
@@ -622,39 +623,39 @@
        - The GPG directory and files, .gnupg/*
 
        yadm will automatically update permissions by default. This can be dis-
-       abled  using  the yadm.auto-perms configuration. Even if disabled, per-
-       missions can be manually updated  by  running  yadm  perms.   The  .ssh
-       directory  processing can be disabled using the yadm.ssh-perms configu-
-       ration. The .gnupg directory  processing  can  be  disabled  using  the
+       abled using the yadm.auto-perms configuration. Even if  disabled,  per-
+       missions  can  be  manually  updated  by  running yadm perms.  The .ssh
+       directory processing can be disabled using the yadm.ssh-perms  configu-
+       ration.  The  .gnupg  directory  processing  can  be disabled using the
        yadm.gpg-perms configuration.
 
-       When  cloning a repo which includes data in a .ssh or .gnupg directory,
-       if those directories do not exist at the time  of  cloning,  yadm  will
+       When cloning a repo which includes data in a .ssh or .gnupg  directory,
+       if  those  directories  do  not exist at the time of cloning, yadm will
        create the directories with mask 0700 prior to merging the fetched data
        into the work-tree.
 
        When running a Git command and .ssh or .gnupg directories do not exist,
-       yadm  will create those directories with mask 0700 prior to running the
+       yadm will create those directories with mask 0700 prior to running  the
        Git command. This can be disabled using the yadm.auto-private-dirs con-
        figuration.
 
 
 ## HOOKS
-       For  every  command  yadm  supports,  a  program can be provided to run
-       before or after that command. These are referred to  as  "hooks".  yadm
-       looks  for  hooks in the directory $HOME/.config/yadm/hooks.  Each hook
+       For every command yadm supports, a  program  can  be  provided  to  run
+       before  or  after  that command. These are referred to as "hooks". yadm
+       looks for hooks in the directory $HOME/.config/yadm/hooks.   Each  hook
        is named using a prefix of pre_ or post_, followed by the command which
-       should  trigger  the  hook.  For example, to create a hook which is run
-       after every yadm pull command, create a hook  named  post_pull.   Hooks
+       should trigger the hook. For example, to create a  hook  which  is  run
+       after  every  yadm  pull command, create a hook named post_pull.  Hooks
        must have the executable file permission set.
 
        If a pre_ hook is defined, and the hook terminates with a non-zero exit
-       status, yadm will refuse to run the yadm command.  For  example,  if  a
-       pre_commit  hook is defined, but that command ends with a non-zero exit
-       status, the yadm commit will never be run. This allows one  to  "short-
+       status,  yadm  will  refuse  to run the yadm command. For example, if a
+       pre_commit hook is defined, but that command ends with a non-zero  exit
+       status,  the  yadm commit will never be run. This allows one to "short-
        circuit" any operation using a pre_ hook.
 
-       Hooks  have  the  following  environment variables available to them at
+       Hooks have the following environment variables  available  to  them  at
        runtime:
 
        YADM_HOOK_COMMAND
@@ -664,7 +665,9 @@
               The exit status of the yadm command
 
        YADM_HOOK_FULL_COMMAND
-              The yadm command with all command line arguments
+              The yadm command with all command line arguments (parameters are
+              space delimited, and any space, tab or backslash will be escaped
+              with a backslash)
 
        YADM_HOOK_REPO
               The path to the yadm repository
@@ -674,13 +677,13 @@
 
 
 ## FILES
-       All of yadm's configurations are  relative  to  the  "yadm  directory".
-       yadm  uses  the  "XDG  Base  Directory Specification" to determine this
-       directory.  If the environment variable $XDG_CONFIG_HOME is defined  as
-       a  fully  qualified path, this directory will be $XDG_CONFIG_HOME/yadm.
+       All  of  yadm's  configurations  are  relative to the "yadm directory".
+       yadm uses the "XDG Base  Directory  Specification"  to  determine  this
+       directory.   If the environment variable $XDG_CONFIG_HOME is defined as
+       a fully qualified path, this directory will  be  $XDG_CONFIG_HOME/yadm.
        Otherwise it will be $HOME/.config/yadm.
 
-       The following are the default paths yadm uses for its own  data.   Most
+       The  following  are the default paths yadm uses for its own data.  Most
        of these paths can be altered using universal options.  See the OPTIONS
        section for details.
 
@@ -692,9 +695,9 @@
               Configuration file for yadm.
 
        $YADM_DIR/alt
-              This  is  a  directory  to keep "alternate files" without having
-              them side-by-side with the resulting symlink or  processed  tem-
-              plate.  Alternate files placed in this directory will be created
+              This is a directory to keep  "alternate  files"  without  having
+              them  side-by-side  with the resulting symlink or processed tem-
+              plate. Alternate files placed in this directory will be  created
               relative to $HOME instead.
 
        $YADM_DIR/repo.git

--- a/yadm.spec
+++ b/yadm.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 Name: yadm
 Summary: Yet Another Dotfiles Manager
-Version: 2.3.0
+Version: 2.4.0
 Group: Development/Tools
 Release: 1%{?dist}
 URL: https://yadm.io


### PR DESCRIPTION
This patch implements extensible support for alternative ciphers (beside GPG) and an OpenSSL cypher (via openssl enc command).

It has to be enabled using `yadm.cypher=<cypher>` configuration option.

I know that encrypt archives with `openssl` and a simple password has its caveats but in some uses cases it may be convinient. Some enhacements for yadm suggests the use of a password manager for (de)encryp files something, that may be possible with this patch.

However there are still some rough edges that should be fixed after some discursion:
- archive file refers to GPG (.gpg extension)
- no test cases