### PR TITLE
support multiple keys in `yadm.gpg-recipient`

### DIFF
--- a/yadm
+++ b/yadm
@@ -425,7 +425,10 @@ function encrypt() {
   if [ "$GPG_KEY" = "ASK" ]; then
     GPG_OPTS=("--no-default-recipient" "-e")
   elif [ "$GPG_KEY" != "" ]; then
-    GPG_OPTS=("-e" "-r $GPG_KEY")
+    GPG_OPTS=("-e")
+    for key in $GPG_KEY; do
+      GPG_OPTS+=("-r $key")
+    done
   else
     GPG_OPTS=("-c")
   fi


### PR DESCRIPTION
This patch allows secrets to be encrypted against multiple gpg keys, very useful if you are using separate encryption subkeys.

Multiple subkeys:
`yadm config yadm.gpg-recipient "ABCDABCDABCDABCD! EF01EF01EF01EF01!"`
(the ! is required to force the use of a (sub)key, as gpg will resolve to the latest valid encryption subkey)

Multiple recipients:
`yadm config yadm.gpg-recipient "bar@example.com foo@example.com"`
