### PR TITLE
Set perms recursively

### DIFF
--- a/.notes.md
+++ b/.notes.md
@@ -1,19 +1,21 @@
 ## New release checklist
-  ○ Version bump EVERYTHING
-  ○ Copyright year update?
-  ○ Rebuild contribs
-  ○ Rebuild man
-  ○ Update specfile
-  ○ Update CHANGES
 
-  ○ Tag X.XX
-  ○ Merge dev → master
-  ○ Update Homebrew
-  ○ Update Copr
+- [ ] Version bump EVERYTHING
+- [ ] Copyright year update?
+- [ ] Rebuild contribs
+- [ ] Rebuild man
+- [ ] Update specfile
+- [ ] Update CHANGES
 
-  ○ Tweet
+- [ ] Tag X.XX
+- [ ] Merge dev → master
+- [ ] Update Homebrew
+- [ ] Update Copr
+
+- [ ] Tweet
 
 ## Homebrew update
+```
   brew update
   cd $(brew --repo homebrew/core)
   git fetch --unshallow origin # only if still a shallow clone,
@@ -33,8 +35,10 @@
   git push TheLocehiliosan master:yadm-X.XX
 
   Open pull request
+```
 
 ## Copr update
+```
   checkout yadm-rpm
   bring in yadm.spec from yadm repo
   update version in Makefile
@@ -53,3 +57,4 @@
     that should leave a src RPM in the yadm-rpm dir
 
   create a new build by uploading the src rpm to copr
+```

--- a/yadm
+++ b/yadm
@@ -1072,17 +1072,9 @@ function parse_encrypt() {
         local IFS=$'\n'
         for pattern in $line; do
           if [[ "$pattern" =~ $exclude_pattern ]]; then
-            for ex_file in ${BASH_REMATCH[1]}; do
-              if [ -e "$ex_file" ]; then
-                ENCRYPT_EXCLUDE_FILES+=("$ex_file")
-              fi
-            done
+            eval "parse_encrypt_exclude ${BASH_REMATCH[1]}"
           else
-            for in_file in $pattern; do
-              if [ -e "$in_file" ]; then
-                ENCRYPT_INCLUDE_FILES+=("$in_file")
-              fi
-            done
+            eval "parse_encrypt_include $pattern"
           fi
         done
       fi
@@ -1105,6 +1097,22 @@ function parse_encrypt() {
     ENCRYPT_INCLUDE_FILES=("${FINAL_INCLUDE[@]}")
   fi
 
+}
+
+function parse_encrypt_exclude() {
+  for ex_file in "$@"; do
+    if [ -e "$ex_file" ]; then
+      ENCRYPT_EXCLUDE_FILES+=("$ex_file")
+    fi
+  done
+}
+
+function parse_encrypt_include() {
+  for in_file in "$@"; do
+    if [ -e "$in_file" ]; then
+      ENCRYPT_INCLUDE_FILES+=("$in_file")
+    fi
+  done
 }
 
 function parse_ignore() {

--- a/yadm
+++ b/yadm
@@ -169,7 +169,7 @@ function alt() {
 
   #; decide if a copy should be done instead of a symbolic link
   local do_copy=0
-  if [[ $OPERATING_SYSTEM =~ (Cygwin|Msys) ]] ; then
+  if [[ $OPERATING_SYSTEM =~ ^(CYGWIN|MSYS) ]] ; then
     if [[ $(config --bool yadm.cygwin-copy) == "true" ]] ; then
       do_copy=1
     fi

--- a/yadm
+++ b/yadm
@@ -797,7 +797,7 @@ function perms() {
   #; remove group/other permissions from collected globs
   #shellcheck disable=SC2068
   #(SC2068 is disabled because in this case, we desire globbing)
-  chmod -f go-rwx ${GLOBS[@]} >/dev/null 2>&1
+  chmod -R -f go-rwx ${GLOBS[@]} >/dev/null 2>&1
   #; TODO: detect and report changing permissions in a portable way
 
 }

--- a/yadm
+++ b/yadm
@@ -936,6 +936,9 @@ function parse_encrypt() {
 
   exclude_pattern="^!(.+)"
   if [ -f "$YADM_ENCRYPT" ] ; then
+    shopt_dotglob="$(shopt -p dotglob)"
+    shopt -s dotglob
+
     #; parse both included/excluded
     while IFS='' read -r line || [ -n "$line" ]; do
       if [[ ! $line =~ ^# && ! $line =~ ^[[:space:]]*$ ]] ; then
@@ -957,6 +960,8 @@ function parse_encrypt() {
         done
       fi
     done < "$YADM_ENCRYPT"
+
+    eval "$shopt_dotglob"
 
     #; remove excludes from the includes
     #(SC2068 is disabled because in this case, we desire globbing)

--- a/yadm
+++ b/yadm
@@ -149,7 +149,7 @@ function alt() {
 
   local_host="$(config local.hostname)"
   if [ -z "$local_host" ] ; then
-    local_host=$(hostname)
+    local_host=$(uname -n)
     local_host=${local_host%%.*} #; trim any domain from hostname
   fi
   match_host="(%|$local_host)"

--- a/yadm
+++ b/yadm
@@ -169,7 +169,7 @@ function alt() {
 
   #; decide if a copy should be done instead of a symbolic link
   local do_copy=0
-  if [[ $OPERATING_SYSTEM == CYGWIN* ]] ; then
+  if [[ $OPERATING_SYSTEM =~ (Cygwin|Msys) ]] ; then
     if [[ $(config --bool yadm.cygwin-copy) == "true" ]] ; then
       do_copy=1
     fi

--- a/yadm
+++ b/yadm
@@ -432,6 +432,11 @@ function encrypt() {
   require_encrypt
   parse_encrypt
 
+  if [ "${#ENCRYPT_INCLUDE_FILES[@]}" -eq 0 ]; then
+    error_out "No files were found to encrypt"
+    return
+  fi
+
   cd_work "Encryption" || return
 
   #; Build gpg options for gpg

--- a/yadm
+++ b/yadm
@@ -196,7 +196,7 @@ function alt() {
                 fi
                 cp -f "$alt_path" "$new_link"
               else
-                ln -nfs "$alt_path" "$new_link"
+                alt_ln "$alt_path" "$new_link"
               fi
               last_linked="$alt_path"
             fi
@@ -232,6 +232,20 @@ function alt() {
     fi
   done
 
+}
+
+function alt_ln() {
+  local alt_dir alt_base new_base
+
+  alt_dir="$(dirname "$1")"
+  alt_base="$(basename "$1")"
+  new_base="$(basename "$2")"
+  if pushd "$alt_dir" >/dev/null ; then
+    ln -nfs "$alt_base" "$new_base"
+    popd &>/dev/null
+  else
+    ln -nfs "$1" "$2"
+  fi
 }
 
 function bootstrap() {

--- a/yadm
+++ b/yadm
@@ -809,11 +809,12 @@ function set_operating_system() {
   fi
 
   case "$OPERATING_SYSTEM" in
-    CYGWIN*)
+    CYGWIN*|MINGW*|MSYS*)
       git_version=$(git --version 2>/dev/null)
       if [[ "$git_version" =~ windows ]] ; then
           USE_CYGPATH=1
       fi
+      OPERATING_SYSTEM=$(uname -o)
       ;;
     *)
       ;;

--- a/yadm
+++ b/yadm
@@ -29,6 +29,7 @@ YADM_CONFIG="config"
 YADM_ENCRYPT="encrypt"
 YADM_ARCHIVE="files.gpg"
 YADM_BOOTSTRAP="bootstrap"
+YADM_GITIGNORE=".gitignore"
 
 HOOK_COMMAND=""
 FULL_COMMAND=""
@@ -42,6 +43,7 @@ PROC_VERSION="/proc/version"
 OPERATING_SYSTEM="Unknown"
 
 ENCRYPT_INCLUDE_FILES="unparsed"
+IGNORE_LINES="unparsed"
 
 #; flag causing path translations with cygpath
 USE_CYGPATH=0
@@ -65,7 +67,7 @@ function main() {
 
   #; parse command line arguments
   local retval=0
-  internal_commands="^(alt|bootstrap|clean|clone|config|decrypt|encrypt|enter|help|init|introspect|list|perms|version)$"
+  internal_commands="^(alt|bootstrap|clean|clone|config|decrypt|encrypt|enter|help|ignore|init|introspect|list|perms|version)$"
   if [ -z "$*" ] ; then
     #; no argumnts will result in help()
     help
@@ -546,6 +548,7 @@ Commands:
   yadm encrypt               - Encrypt files
   yadm decrypt [-l]          - Decrypt files
   yadm perms                 - Fix perms for private files
+  yadm ignore                - Add ~/.yadm/encrypt entries to ~/.gitignore
 
 Files:
   \$HOME/.yadm/config    - yadm's configuration file
@@ -557,6 +560,112 @@ Use "man yadm" for complete documentation.
 EOF
 
   exit_with_hook 1
+
+}
+
+function ignore() {
+
+  require_repo
+  require_encrypt
+  parse_encrypt
+  parse_ignore
+
+  if [[ "${#ENCRYPT_INCLUDE_FILES[@]}" -eq 0 ]]; then
+    error_out "No files were found to encrypt"
+    return
+  fi
+
+  local loud
+  [[ "$YADM_COMMAND" = "ignore" ]] && loud="YES"
+
+  cd_work "Ignore" || return
+
+  local new_ignores
+  new_ignores=()
+
+  # ignore specifications listed in ~/.yadm/encrypt
+  local line eline iline found
+  local IFS
+  while IFS='' read -r line || [ -n "$line" ]; do
+    # trim leading and trailing whitespace
+    line="$(sed 's/^[[:blank:]]*//;s/[[:blank:]]*$//' <<<"$line")"
+    if [[ -z "$line" || "$line" =~ ^# ]]; then
+      continue
+    fi
+    # don't ignore non-encrypted files
+    if [[ "$line" =~ ^! ]]; then
+      continue
+    fi
+    eline="$line"
+    if [[ "$eline" =~ ^/ ]]; then
+      eline="${eline:1}"
+    fi
+    found=0
+    for iline in "${IGNORE_LINES[@]}"; do
+      if [[ "$iline" = "$line" ]]; then
+        found=1
+        break
+      fi
+      if [[ "$iline" =~ ^/ ]]; then
+        iline="${iline:1}"
+        if [[ "$iline" = "$eline" ]]; then
+          found=1
+          break
+        fi
+      fi
+    done
+    # skip files that have already been ignored
+    if [[ "$found" -eq 1 ]]; then
+      continue
+    fi
+    debug "Adding /$eline to $YADM_GITIGNORE"
+    [[ -n "$loud" ]] && echo "Adding /$eline to $YADM_GITIGNORE"
+    # add a / to anchor the search in the home directory.
+    new_ignores+=("/$eline")
+    IGNORE_LINES+=("/$eline")
+  done < "$YADM_ENCRYPT"
+
+  # ignore template files used to generate the files listed in ~/.yadm/encrypt
+  # this will match ##yadm.j2 files as well.
+  local match="^(.+)##"
+  local file
+  for file in "${ENCRYPT_INCLUDE_FILES[@]}"; do
+    if [[ ! "$file" =~ $match ]]; then
+      continue
+    fi
+    file="${BASH_REMATCH[1]}"
+    found=0
+    for iline in "${IGNORE_LINES[@]}"; do
+      if [[ "$iline" = "$file" ]]; then
+        found=1
+        break
+      fi
+      if [[ "${iline:0:1}" = "/" ]]; then
+        iline="${iline:1}"
+        if [[ "$iline" = "$file" ]]; then
+          found=1
+          break
+        fi
+      fi
+    done
+    # skip files that have already been ignored
+    if [[ "$found" -eq 1 ]]; then
+      continue
+    fi
+    debug "Adding /$file to $YADM_GITIGNORE."
+    [[ -n "$loud" ]] && echo "Adding /$file to $YADM_GITIGNORE."
+    # add a / to anchor the search in the home directory.
+    new_ignores+=("/$file")
+    IGNORE_LINES+=("/$file")
+  done
+
+  if [[ "${#new_ignores[@]}" -eq 0 ]]; then
+    echo_e "$YADM_GITIGNORE already has all the entries from $YADM_ENCRYPT"
+    return 0
+  fi
+
+  printf "\n# Added by 'yadm ignore' on %s:\n" "$(date)" >> "$YADM_GITIGNORE"
+  printf "%s\n" "${new_ignores[@]}" >> "$YADM_GITIGNORE"
 
 }
 
@@ -601,6 +710,7 @@ encrypt
 enter
 gitconfig
 help
+ignore
 init
 introspect
 list
@@ -638,6 +748,7 @@ function introspect_switches() {
 --yadm-config
 --yadm-dir
 --yadm-encrypt
+--yadm-ignore
 --yadm-repo
 -Y
 EOF
@@ -757,6 +868,13 @@ function process_global_args() {
         YADM_OVERRIDE_BOOTSTRAP="$2"
         shift
       ;;
+      --yadm-gitignore) #; override the standard YADM_GITIGNORE
+        if [[ ! "$2" =~ ^/ ]] ; then
+          error_out "You must specify a fully qualified encrypt path"
+        fi
+        YADM_OVERRIDE_GITIGNORE="$2"
+        shift
+      ;;
       *) #; main arguments are kept intact
         MAIN_ARGS+=("$1")
       ;;
@@ -774,6 +892,7 @@ function configure_paths() {
   YADM_ENCRYPT="$YADM_DIR/$YADM_ENCRYPT"
   YADM_ARCHIVE="$YADM_DIR/$YADM_ARCHIVE"
   YADM_BOOTSTRAP="$YADM_DIR/$YADM_BOOTSTRAP"
+  YADM_GITIGNORE="$YADM_WORK/$YADM_GITIGNORE"
 
   #; independent overrides for paths
   if [ -n "$YADM_OVERRIDE_REPO" ]; then
@@ -790,6 +909,9 @@ function configure_paths() {
   fi
   if [ -n "$YADM_OVERRIDE_BOOTSTRAP" ]; then
     YADM_BOOTSTRAP="$YADM_OVERRIDE_BOOTSTRAP"
+  fi
+  if [ -n "$YADM_OVERRIDE_GITIGNORE" ]; then
+    YADM_GITIGNORE="$YADM_OVERRIDE_GITIGNORE"
   fi
 
   #; use the yadm repo for all git operations
@@ -982,6 +1104,34 @@ function parse_encrypt() {
     done
     ENCRYPT_INCLUDE_FILES=("${FINAL_INCLUDE[@]}")
   fi
+
+}
+
+function parse_ignore() {
+
+  IGNORE_LINES=()
+
+  if [ ! -e "$YADM_GITIGNORE" ]; then
+    return 0
+  fi
+
+  cd_work "Parsing $YADM_GITIGNORE" || return
+
+  #; parse both included/excluded
+  local IFS
+  local line
+  local match="^!(.+)"
+  while IFS=$'\n' read -r line; do
+    # trim leading and trailing whitespace
+    line="$(sed 's/^[[:blank:]]*//;s/[[:blank:]]*$//' <<<"$line")"
+    if [[ -z "$line" || "$line" =~ ^# ]]; then
+      continue
+    fi
+    if [[ "$line" =~ $match ]]; then
+      line="${BASH_REMATCH[1]}"
+    fi
+    IGNORE_LINES+=("$line")
+  done < "$YADM_GITIGNORE"
 
 }
 


### PR DESCRIPTION
I found that `yadm perms` fails for configurations that have the following in `.ssh/config`:
```
Include conf.d/* 
```
This PR fixes that.