### PR TITLE
Run hooks on MINGW* systems

### DIFF
--- a/yadm
+++ b/yadm
@@ -848,7 +848,7 @@ function invoke_hook() {
   exit_status="$2"
   hook_command="$YADM_DIR/hooks/${mode}_$HOOK_COMMAND"
 
-  if [ -x "$hook_command" ] ; then
+  if [ -x "$hook_command" ] || ( [[ $OPERATING_SYSTEM == MINGW* ]] && [ -f "$hook_command" ] ) ; then
     debug "Invoking hook: $hook_command"
 
     #; expose some internal data to all hooks


### PR DESCRIPTION
### What does this PR do?

MINGW* systems don't have a +x flag.
Everything is executable if it exists (as far as I know).

This, while trying to run hooks on MINGW* systems just check
for the existence of the file instead of -x

### What issues does this PR fix or reference?

None filed (just discovered this while trying to make use of hooks within a MINGW system.

### Previous Behavior

The hook would not run when created.
There would also be no debug output saying that the hook exists in the correct location, but was no executable. (I might add this in a follow up?)

### New Behavior

Hooks that have been created on MINGW systems now correctly run:

```
$ yadm alt -d
DEBUG: Invoking hook: /c/Users/me/.yadm/hooks/pre_alt
Setting variables for templates
```

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
