### PR TITLE
Replace direkt calls to git with $GIT_PROGRAM

### DIFF
--- a/yadm
+++ b/yadm
@@ -410,13 +410,13 @@ EOF
 
     # operate on the yadm repo's configuration file
     # this is always local to the machine
-    git config --local "$@"
+    $GIT_PROGRAM config --local "$@"
 
     CHANGES_POSSIBLE=1
 
   else
     # operate on the yadm configuration file
-    git config --file="$(mixed_path "$YADM_CONFIG")" "$@"
+    $GIT_PROGRAM config --file="$(mixed_path "$YADM_CONFIG")" "$@"
 
   fi
 
@@ -844,7 +844,7 @@ function set_operating_system() {
 
   case "$OPERATING_SYSTEM" in
     CYGWIN*)
-      git_version=$(git --version 2>/dev/null)
+      git_version=$($GIT_PROGRAM --version 2>/dev/null)
       if [[ "$git_version" =~ windows ]] ; then
           USE_CYGPATH=1
       fi


### PR DESCRIPTION
 
### What does this PR do?
It replaces direct calls to `git` with calls using the `$GIT_PROGRAM` variable. 

### What issues does this PR fix or reference?
no corresponding issue


### Previous Behavior

Some calls to git ignored the `yadm.gpg-program` configuration option and called the first git found in `$PATH` instead.

### New Behavior

All calls to git use the `$GIT_PROGRAM` variable, that adheres to the `yadm.gpg-program` configuration option.


### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?
Yes

---
### Testresults

Tests have been run in yadm/testbed container and mostly passed. Failures/Warnings were along these lines: 
```bash
XFAIL test/test_alt.py::test_wild[tracked-##C.S.H.U-C-S%-H%-U]                             
  reason: This test is known to be broken. This bug needs to be fixed.

test/test_enter.py::test_enter[shell-missing]                            
  /yadm/test/test_enter.py:46: Warning: Unhandled bug: SHELL executed when empty
    warnings.warn('Unhandled bug: SHELL executed when empty', Warning)     
```

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
