### PR TITLE
Don't glob into parent dirs

### DIFF
--- a/yadm
+++ b/yadm
@@ -1045,12 +1045,12 @@ function perms() {
 
   # include all .ssh files (unless disabled)
   if [[ $(config --bool yadm.ssh-perms) != "false" ]] ; then
-    GLOBS+=(".ssh" ".ssh/*" ".ssh/.*")
+    GLOBS+=(".ssh" ".ssh/*" ".ssh/.[!.]*")
   fi
 
   # include all gpg files (unless disabled)
   if [[ $(config --bool yadm.gpg-perms) != "false" ]] ; then
-    GLOBS+=(".gnupg" ".gnupg/*" ".gnupg/.*")
+    GLOBS+=(".gnupg" ".gnupg/*" ".gnupg/.[!.]*")
   fi
 
   # include any files we encrypt


### PR DESCRIPTION
### What does this PR do?

Keeps chmod from setting perms in the parent directory of .ssh and .gnupg

### What issues does this PR fix or reference?

None.

### Previous Behavior

chmod would descend into .ssh/.. and .gnupg/..

### New Behavior

chmod doesn't descend into .ssh/.. and .gnupg/..

### Have [tests][1] been written for this change?

Yes.

### Have these commits been [signed with GnuPG][2]?

No

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
