### PR TITLE
Yaourt unmaintained and security risk don't mention it

### DIFF
--- a/_docs/020_install.md
+++ b/_docs/020_install.md
@@ -25,10 +25,10 @@ A version of yadm is available via standard package repositories. Use `apt-get` 
 
 ## Arch Linux
 
-yadm is available in the Arch User Repos and can be installed with AUR helper or Makepkg.
+yadm is available in the [Arch User Repos](https://wiki.archlinux.org/index.php/Arch_User_Repository) and can be installed with an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers) or with [Makepkg](https://wiki.archlinux.org/index.php/Makepkg).
 
 ```
-yaourt -S yadm-git
+yay -Syu yadm-git
 ```
 
 ## Gentoo Linux


### PR DESCRIPTION
Don't mention Yaourt, it's unmaintained and has security issues and isn't even mentioned on the [AUR Helpers](https://wiki.archlinux.org/index.php/AUR_helpers) page anymore. Use Yay instead.

- [Yaourt is Dead! Use These Alternatives for AUR in Arch Linux](https://itsfoss.com/best-aur-helpers/)
- https://github.com/archlinuxfr/yaourt/issues/382#issuecomment-475039781
- [What's so bad with yaourt?](https://reddit.com/comments/4azqyb/)
