### PR TITLE
Don't get people to do #!/bin/bash either use /bin/sh or #!/usr/bin/e…

### DIFF
--- a/_docs/050_bootstrap.md
+++ b/_docs/050_bootstrap.md
@@ -41,7 +41,7 @@ If you've added repositories as submodules for the yadm repository, you can
 initialize them after a successful clone.
 
 ```bash
-#!/bin/bash
+#!/bin/sh
 
 # Because Git submodule commands cannot operate without a work tree, they must
 # be run from within $HOME (assuming this is the root of your dotfiles)
@@ -54,7 +54,7 @@ yadm submodule update --recursive --init
 ### Install [Homebrew](http://brew.sh/) and a bundle of recipes
 
 ```bash
-#!/bin/bash
+#!/bin/sh
 
 system_type=$(uname -s)
 
@@ -77,7 +77,7 @@ fi
 ### Configure [iTerm2](http://www.iterm2.com/) to use your configuration
 
 ```bash
-#!/bin/bash
+#!/bin/sh
 
 system_type=$(uname -s)
 
@@ -97,7 +97,7 @@ fi
 ### Compile a custom terminfo file
 
 ```bash
-#!/bin/bash
+#!/bin/sh
 
 if [ -f "$HOME/.terminfo/custom.terminfo" ]; then
   echo "Updating terminfo"
@@ -112,7 +112,7 @@ available after cloning. If so, you could update the yadm repo origin to use
 `ssh` instead.
 
 ```bash
-#!/bin/bash
+#!/bin/sh
 
 echo "Updating the yadm repo origin URL"
 yadm remote set-url origin "git@github.com:MyUser/dotfiles.git"
@@ -159,7 +159,7 @@ will install any new plugins, and also remove any plugins now deleted from your
 `.vimrc`.
 
 ```bash
-#!/bin/bash
+#!/bin/sh
 
 if command -v vim >/dev/null 2>&1; then
   echo "Bootstraping Vim"


### PR DESCRIPTION
It's probably best people write their bootstrap using POSIX `sh`, particularly if it's likely they might use that bootstrap on say Linux and then maybe a a Mac (which does not have ancient [bash 3.2, but rather zsh](https://support.apple.com/en-us/HT208050) now). This article provides a bit further argument to that: [Introduction to POSIX shell](https://drewdevault.com/2018/02/05/Introduction-to-POSIX-shell.html).

Relevant to your [last](https://github.com/TheLocehiliosan/yadm/pull/178/commits/4313f890bd2168097e1b63cd7d138418f2200c44#diff-92b171ffea085fc23f3a361a2598898fR164) example there [`command -v` recommended over hash/type for POSIX scripts](https://stackoverflow.com/a/677212) which is already the POSIX way to do it.

If `/bin/sh` is not enough, then writing an external program in Python (or some other language) and then calling it in your `/bin/sh` script is the way to go. In any case if you **do** insist on using bash, then you should use [`#!/usr/bin/env bash`](https://stackoverflow.com/questions/16365130/what-is-the-difference-between-usr-bin-env-bash-and-usr-bin-bash).


