### PR TITLE
support alternative files in submodules

### DIFF
--- a/yadm
+++ b/yadm
@@ -427,6 +427,12 @@ function alt() {
     tracked_files+=("$tracked_file")
   done
 
+  for tracked_file in $(
+    "$GIT_PROGRAM" submodule foreach 'git ls-files | sed "s|^|$path/|"' |
+      LC_ALL=C sort); do
+        tracked_files+=("$tracked_file")
+  done
+
   # generate data for removing stale links
   local possible_alts
   possible_alts=()


### PR DESCRIPTION
### What does this PR do?

I would like to support alt-files in submodules.

### What issues does this PR fix or reference?

This is related to reported feature request: https://github.com/TheLocehiliosan/yadm/issues/78

[A list of related issues / pull requests.]
#78 
### Previous Behavior

Alt files ending with e.g. `##os.solaris` are ignored in submodules.

### New Behavior

Alt files are from submodules generate symlinks

```
$ y submodule
 79ebb378bac037d0a515ce926e98bf8eb16ac35f vim (heads/master)
$ y alt
Linking /home/jaroslav/.Profile/Xdefaults/Xdefaults.fonts##h.balmora to /home/jaroslav/.Profile/Xdefaults/Xdefaults.fonts
Linking /home/jaroslav/.Profile/vim/autoload/fonts##h.balmora to /home/jaroslav/.Profile/vim/autoload/fonts
```

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

No

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
