### PR TITLE
Remove quotes from distro name

### DIFF
--- a/yadm
+++ b/yadm
@@ -1262,6 +1262,7 @@ function query_distro() {
     while IFS='' read -r line || [ -n "$line" ]; do
       if [[ "$line" = ID=* ]]; then
         distro="${line#ID=}"
+        distro="${distro//\"}"
         break
       fi
     done < "$OS_RELEASE"


### PR DESCRIPTION
### What does this PR do?

Removes quotes from ID variable read from `/etc/os-release` 

### What issues does this PR fix or reference?

See above

### Previous Behavior

distro="OpenWrt"

### New Behavior

distro=OpenWrt

### Have [tests][1] been written for this change?

No.

### Have these commits been [signed with GnuPG][2]?

Yes