### PR TITLE
Fix leading vim comment

### DIFF
--- a/yadm.1
+++ b/yadm.1
@@ -1,4 +1,4 @@
-." vim: set spell so=8:
+.\" vim: set spell so=8:
 .TH yadm 1 "17 December 2019" "2.3.0"
 
 .SH NAME


### PR DESCRIPTION
Change `."` to `.\"` for a *roff comment.  `."` appears to do the
same thing, but only accidentally because it's treated as an unknown
macro and then ignored by default.  `man --warnings` will show the
problem:

```
% man --warnings ./yadm.1 > /dev/null
troff: <standard input>:1: warning: macro '"' not defined
```