### PR TITLE
Support architecture in alternates (#202)

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -8,7 +8,7 @@ max-attributes=8
 max-statements=65
 
 [SIMILARITIES]
-min-similarity-lines=6
+min-similarity-lines=7
 
 [MESSAGES CONTROL]
 disable=redefined-outer-name

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -75,6 +75,12 @@ def tst_sys():
 
 
 @pytest.fixture(scope='session')
+def tst_arch():
+    """Test session's uname value"""
+    return platform.machine()
+
+
+@pytest.fixture(scope='session')
 def supported_commands():
     """List of supported commands
 

--- a/test/test_alt.py
+++ b/test/test_alt.py
@@ -81,6 +81,7 @@ def test_relative_link(runner, paths, yadm_alt):
 @pytest.mark.usefixtures('ds1_copy')
 @pytest.mark.parametrize('suffix', [
     '##default',
+    '##a.$tst_arch', '##arch.$tst_arch', '##architecture.$tst_arch',
     '##o.$tst_sys', '##os.$tst_sys',
     '##d.$tst_distro', '##distro.$tst_distro',
     '##c.$tst_class', '##class.$tst_class',
@@ -89,7 +90,7 @@ def test_relative_link(runner, paths, yadm_alt):
     ])
 def test_alt_conditions(
         runner, paths,
-        tst_sys, tst_distro, tst_host, tst_user, suffix):
+        tst_arch, tst_sys, tst_distro, tst_host, tst_user, suffix):
     """Test conditions supported by yadm alt"""
     yadm_dir = setup_standard_yadm_dir(paths)
 
@@ -98,6 +99,7 @@ def test_alt_conditions(
     utils.set_local(paths, 'class', tst_class)
 
     suffix = string.Template(suffix).substitute(
+        tst_arch=tst_arch,
         tst_sys=tst_sys,
         tst_distro=tst_distro,
         tst_class=tst_class,

--- a/yadm
+++ b/yadm
@@ -175,37 +175,44 @@ function score_file() {
     if [[ "$label" =~ ^(default)$ ]]; then
       score=$((score + 0))
     # variable conditions
+    elif [[ "$label" =~ ^(a|arch|architecture)$ ]]; then
+      if [ "$value" = "$local_arch" ]; then
+        score=$((score + 1))
+      else
+        score=0
+        return
+      fi
     elif [[ "$label" =~ ^(o|os)$ ]]; then
       if [ "$value" = "$local_system" ]; then
-        score=$((score + 1))
+        score=$((score + 2))
       else
         score=0
         return
       fi
     elif [[ "$label" =~ ^(d|distro)$ ]]; then
       if [ "$value" = "$local_distro" ]; then
-        score=$((score + 2))
+        score=$((score + 4))
       else
         score=0
         return
       fi
     elif [[ "$label" =~ ^(c|class)$ ]]; then
       if [ "$value" = "$local_class" ]; then
-        score=$((score + 4))
+        score=$((score + 8))
       else
         score=0
         return
       fi
     elif [[ "$label" =~ ^(h|hostname)$ ]]; then
       if [ "$value" = "$local_host" ]; then
-        score=$((score + 8))
+        score=$((score + 16))
       else
         score=0
         return
       fi
     elif [[ "$label" =~ ^(u|user)$ ]]; then
       if [ "$value" = "$local_user" ]; then
-        score=$((score + 16))
+        score=$((score + 32))
       else
         score=0
         return
@@ -367,6 +374,7 @@ EOF
 
   "${AWK_PROGRAM[0]}" \
     -v class="$local_class" \
+    -v arch="$local_arch" \
     -v os="$local_system" \
     -v host="$local_host" \
     -v user="$local_user" \
@@ -383,6 +391,7 @@ function template_j2cli() {
   temp_file="${output}.$$.$RANDOM"
 
   YADM_CLASS="$local_class"   \
+  YADM_ARCH="$local_arch"     \
   YADM_OS="$local_system"     \
   YADM_HOSTNAME="$local_host" \
   YADM_USER="$local_user"     \
@@ -398,6 +407,7 @@ function template_envtpl() {
   temp_file="${output}.$$.$RANDOM"
 
   YADM_CLASS="$local_class"   \
+  YADM_ARCH="$local_arch"     \
   YADM_OS="$local_system"     \
   YADM_HOSTNAME="$local_host" \
   YADM_USER="$local_user"     \
@@ -416,6 +426,7 @@ function alt() {
 
   # gather values for processing alternates
   local local_class
+  local local_arch
   local local_system
   local local_host
   local local_user
@@ -526,6 +537,11 @@ function remove_stale_links() {
 function set_local_alt_values() {
 
   local_class="$(config local.class)"
+
+  local_arch="$(config local.arch)"
+  if [ -z "$local_arch" ] ; then
+    local_arch=$(uname -m)
+  fi
 
   local_system="$(config local.os)"
   if [ -z "$local_system" ] ; then
@@ -656,6 +672,7 @@ function alt_past_linking() {
           [ -n "$loud" ] && echo "Creating $real_file from template $tracked_file"
           temp_file="${real_file}.$$.$RANDOM"
           YADM_CLASS="$local_class"   \
+          YADM_ARCH="$local_arch"     \
           YADM_OS="$local_system"     \
           YADM_HOSTNAME="$local_host" \
           YADM_USER="$local_user"     \

--- a/yadm.1
+++ b/yadm.1
@@ -513,6 +513,11 @@ Valid if the value matches the OS.
 OS is calculated by running
 .BR "uname -s" .
 .TP
+.BR architecture , " arch" , " a
+Valid if the value matches the architecture.
+Architecture is calculated by running
+.BR "uname -m" .
+.TP
 .BR class , " c
 Valid if the value matches the
 .B local.class


### PR DESCRIPTION
### What does this PR do?

Adds architecture support in alternates

### What issues does this PR fix or reference?

#202 

### Previous Behavior

Can only use class, OS, host, distro, etc

### New Behavior

Now architecture (from `uname -m`) can be used as an alternate.

### Have tests been written for this change?

Yes

### Have these commits been signed with GnuPG?

Yes
