### PR TITLE
Fix typo in templates directives example

### DIFF
--- a/_docs/070_templates.md
+++ b/_docs/070_templates.md
@@ -93,7 +93,7 @@ directive as there is in Jinja. Here is an example.
 {% if yadm.os == "Darwin" %}
 This block is included for MacOS
 {% else %}
-This block is included for for any other OS
+This block is included for any other OS
 {% endif %}
 ```
 


### PR DESCRIPTION
### What does this PR do?

A simple typo fix in gh-pages (https://yadm.io/docs/templates#built-in-directives)

### What issues does this PR fix or reference?

None

### Previous Behavior

```
{% else %}
This block is included for for any other OS
{% endif %}
```

### New Behavior

```
{% else %}
This block is included for any other OS
{% endif %}
```

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md