### PR TITLE
Fix regexp with space for OSH compat

### DIFF
--- a/yadm
+++ b/yadm
@@ -1318,7 +1318,8 @@ function is_valid_branch_name() {
   #  * "~", "^", ":", "\", space
   #  * end with a "/"
   #  * end with ".lock"
-  [[ "$1" =~ (\/\.|\.\.|[~^:\\ ]|\/$|\.lock$) ]] && return 1
+  pattern='(\/\.|\.\.|[~^:\\ ]|\/$|\.lock$)'
+  [[ "$1" =~ $pattern ]] && return 1
   return 0
 }
 


### PR DESCRIPTION
### What does this PR do?

Extracts a single regular expression into a separate statement. 

This is a small compatibility tweak for the Oil shell (see https://github.com/oilshell/oil/issues/606) that hopefully won't otherwise change behavior.

### Previous Behavior

Here I've defined the function in bash and run it over a variety of inputs that cover most of what the comment discusses:
```
bash4.4$ function is_valid_branch_name() {
>   # Git branches do not allow:
>   #  * path component that begins with "."
>   #  * double dot
>   #  * "~", "^", ":", "\", space
>   #  * end with a "/"
>   #  * end with ".lock"
>   [[ "$1" =~ (\/\.|\.\.|[~^:\\ ]|\/$|\.lock$) ]] && return 1
>   return 0
> }

bash4.4$ is_valid_branch_name "blah"; echo $?
0
bash4.4$ is_valid_branch_name "fix/blah"; echo $?
0
bash4.4$ is_valid_branch_name "fix/.blah"; echo $?
1
bash4.4$ is_valid_branch_name "fix/~blah"; echo $?
1
bash4.4$ is_valid_branch_name "fix/^blah"; echo $?
1
bash4.4$ is_valid_branch_name "fix/:blah"; echo $?
1
bash4.4$ is_valid_branch_name "fix/\blah"; echo $?
1
bash4.4$ is_valid_branch_name "fix/ blah"; echo $?
1
bash4.4$ is_valid_branch_name "fix/ blah/"; echo $?
1
bash4.4$ is_valid_branch_name "fix/blah/"; echo $?
1
bash4.4$ is_valid_branch_name "fix/blah.lock"; echo $?
```

The function definition itself won't pass in osh:
```
osh$ function is_valid_branch_name() {
>   # Git branches do not allow:
>   #  * path component that begins with "."
>   #  * double dot
>   #  * "~", "^", ":", "\", space
>   #  * end with a "/"
>   #  * end with ".lock"
>   [[ "$1" =~ (\/\.|\.\.|[~^:\\ ]|\/$|\.lock$) ]] && return 1
    [[ "$1" =~ (\/\.|\.\.|[~^:\\ ]|\/$|\.lock$) ]] && return 1
                                 ^
[ interactive ]:8: Expected ]]
osh$   return 0
```

### New Behavior

I repeated this process with the new code as well:
```
bash4.4$ function is_valid_branch_name() {
>   # Git branches do not allow:
>   #  * path component that begins with "."
>   #  * double dot
>   #  * "~", "^", ":", "\", space
>   #  * end with a "/"
>   #  * end with ".lock"
>   pattern='(\/\.|\.\.|[~^:\\ ]|\/$|\.lock$)'
>   [[ "$1" =~ $pattern ]] && return 1
>   return 0
> }

bash4.4$ is_valid_branch_name "blah"; echo $?
0
bash4.4$ is_valid_branch_name "fix/blah"; echo $?
0
bash4.4$ is_valid_branch_name "fix/.blah"; echo $?
1
bash4.4$ is_valid_branch_name "fix/~blah"; echo $?
1
bash4.4$ is_valid_branch_name "fix/^blah"; echo $?
1
bash4.4$ is_valid_branch_name "fix/:blah"; echo $?
1
bash4.4$ is_valid_branch_name "fix/\blah"; echo $?
1
bash4.4$ is_valid_branch_name "fix/ blah"; echo $?
1
bash4.4$ is_valid_branch_name "fix/ blah/"; echo $?
1
bash4.4$ is_valid_branch_name "fix/blah/"; echo $?
1
bash4.4$ is_valid_branch_name "fix/blah.lock"; echo $?
1
```

Osh accepts the definition and passes fine:

```
osh$ function is_valid_branch_name() {
>   # Git branches do not allow:
>   #  * path component that begins with "."
>   #  * double dot
>   #  * "~", "^", ":", "\", space
>   #  * end with a "/"
>   #  * end with ".lock"
>   pattern='(\/\.|\.\.|[~^:\\ ]|\/$|\.lock$)'
>   [[ "$1" =~ $pattern ]] && return 1
>   return 0
> }
osh$ is_valid_branch_name "blah"; echo $?
0
osh$ is_valid_branch_name "fix/blah"; echo $?
0
osh$ is_valid_branch_name "fix/.blah"; echo $?
1
osh$ is_valid_branch_name "fix/~blah"; echo $?
1
osh$ is_valid_branch_name "fix/^blah"; echo $?
1
osh$ is_valid_branch_name "fix/:blah"; echo $?
1
osh$ is_valid_branch_name "fix/\blah"; echo $?
1
osh$ is_valid_branch_name "fix/ blah"; echo $?
1
osh$ is_valid_branch_name "fix/ blah/"; echo $?
1
osh$ is_valid_branch_name "fix/blah/"; echo $?
1
osh$ is_valid_branch_name "fix/blah.lock"; echo $?
1
```

### Have tests been written for this change?

No

### Have these commits been signed with GnuPG?

Yes

