### PR TITLE
Assert existence of config file's parent directory

### DIFF
--- a/test/test_config.py
+++ b/test/test_config.py
@@ -155,7 +155,6 @@ def test_config_without_parent_directory(runner, yadm_y, paths):
     assert run.err == ''
     assert run.out == ''
 
-    paths.config.write(TEST_FILE)
     run = runner(yadm_y('--yadm-config', config_file, 'config', TEST_KEY))
 
     assert run.success

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -137,3 +137,27 @@ def test_config_local_write(runner, yadm_y, paths, supported_local_configs):
         assert run.success
         assert run.err == ''
         assert run.out.strip() == f'value_of_{config}'
+
+
+def test_config_without_parent_directory(runner, yadm_y, paths):
+    """Write and read attribute to/from config file with non-existent parent directory
+
+    Update configuration file
+    Display value
+    Exit with 0
+    """
+
+    config_file = paths.root + '/folder/does/not/exist/config'
+
+    run = runner(yadm_y('--yadm-config', config_file, 'config', TEST_KEY, TEST_VALUE))
+
+    assert run.success
+    assert run.err == ''
+    assert run.out == ''
+
+    paths.config.write(TEST_FILE)
+    run = runner(yadm_y('--yadm-config', config_file, 'config', TEST_KEY))
+
+    assert run.success
+    assert run.err == ''
+    assert run.out.strip() == TEST_VALUE

--- a/yadm
+++ b/yadm
@@ -849,6 +849,8 @@ EOF
     CHANGES_POSSIBLE=1
 
   else
+    # make sure parent folder of config file exists
+    assert_parent "$YADM_CONFIG"
     # operate on the yadm configuration file
     "$GIT_PROGRAM" config --file="$(mixed_path "$YADM_CONFIG")" "$@"
 


### PR DESCRIPTION
Fixes TheLocehiliosan/yadm#226

When a config file path is passed to yadm whose parent directory does
not exist, git (and hence yadm) fails without writing the file.
Yadm should, however, make sure that the directory exists s.t. git can
just write to the file.

### What does this PR do?

Make sure that a config file's parent directory exists before making git try to write to it.
Adds a test to reproduce the problem.

### What issues does this PR fix or reference?

#226

### Previous Behavior

Git, and hence yadm, fails when specifying a config file in a non-existent directory via `--yadm-config`.

### New Behavior

Yadm makes sure the parent directory exists before letting git write to it.

### Have [tests][1] been written for this change?

Yes

### Have these commits been [signed with GnuPG][2]?

No

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
