### PR TITLE
Simplify zsh completion install

### DIFF
--- a/completion/README.md
+++ b/completion/README.md
@@ -1,36 +1,50 @@
 # Installation
 
 ## Bash completions
+
 ### Prerequisites
+
 **yadm** completion only works if Git completions are also enabled.
 
 ### Homebrew
-If using `homebrew` to install **yadm**, completions should automatically be handled if you also install `brew install bash-completion`. This might require you to include the main completion script in your own bashrc file like this:
-```
+
+If using `homebrew` to install **yadm**, completions should automatically be
+handled if you also install `brew install bash-completion`. This might require
+you to include the main completion script in your own bashrc file like this:
+
+```bash
 [ -f /usr/local/etc/bash_completion ] && source /usr/local/etc/bash_completion
 ```
 
 ### Manual installation
+
 Copy the completion script locally, and add this to you bashrc:
-```
+
+```bash
 [ -f /full/path/to/yadm.bash_completion ] && source /full/path/to/yadm.bash_completion
 ```
 
 ## Zsh completions
+
 ### Homebrew
+
 If using `homebrew` to install **yadm**, completions should handled automatically.
 
 ### Manual installation
-Copy the completion script `yadm.zsh_completion` locally, rename it to `_yadm`, and add the containing folder to `$fpath` in `.zshrc`:
-```
-fpath=(/path/to/folder/containing_yadm $fpath)
+
+Add the `completion/zsh` folder to `$fpath` in `.zshrc`:
+
+```zsh
+fpath=(/full/path/to/yadm/completion/zsh $fpath)
 autoload -U compinit
 compinit
 ```
 
 ### Installation using [zplug](https://github.com/b4b4r07/zplug)
+
 Load `_yadm` as a plugin in your `.zshrc`:
-```
+
+```zsh
 fpath=("$ZPLUG_HOME/bin" $fpath)
 zplug "TheLocehiliosan/yadm", rename-to:_yadm, use:"completion/yadm.zsh_completion", as:command, defer:2
 ```

--- a/completion/zsh/_yadm
+++ b/completion/zsh/_yadm
@@ -1,0 +1,1 @@
+yadm.zsh_completion


### PR DESCRIPTION
### What does this PR do?

Removes an extra step for installing zsh completions.

### What issues does this PR fix or reference?

None.

### Previous Behavior

zsh completion install requires copying or linking to the `yadm.zsh_completion` into a folder with zsh completions as `_yadm`. 

### New Behavior

This includes a folder you can include in your zsh completions automatically, removing that step and updating the documentation to reflect that. It links to the existing `yadm.zsh_completion` file so no existing workflow is affected and there is still only one file to maintain.

### Have [tests][1] been written for this change?

No, I don't believe there are any tests for completions and this is a non-breaking change to the current behavior (the original completion file remains untouched). 

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
