### PR TITLE
Adjust file mode check for BSD based systems

### DIFF
--- a/yadm
+++ b/yadm
@@ -1944,7 +1944,8 @@ function get_mode {
   mode=$(stat -c '%a' "$filename" 2>/dev/null)
   if [ -z "$mode" ] ; then
     # BSD-style
-    mode=$(stat -f '%A' "$filename" 2>/dev/null)
+    # Using the `cut` command to match the output of GNU stat output
+    mode=$(stat -f '%p' "$filename" | cut -c4-6 2>/dev/null)
   fi
 
   # only accept results if they are octal


### PR DESCRIPTION
### What does this PR do?

Adjusts the file mode check for BSD based systems as default BSD stat
uses "-f '%p'" to report the file mode. Also since `stat -p '%p'
"$filename"` reports more information than just read, write, execute
perms, pipe the output through `cut` to grab only the last three digits.

### What issues does this PR fix or reference?

#243
### Previous Behavior

```
-rw-r--r--  1 vendion  vendion   6.8K Aug 10 19:47 autostart
-rwxr-xr-x  1 vendion  vendion   7.4K Jul 12 11:40 autostart##template*
```

### New Behavior

```
-rwxr-xr-x  1 vendion  vendion   6.8K Aug 19 09:29 autostart*
-rwxr-xr-x  1 vendion  vendion   7.4K Jul 12 11:40 autostart##template*
```

### Have [tests][1] been written for this change?

Manual testing has been done (see output above), as `make test` requires docker.

### Have these commits been [signed with GnuPG][2]?

Yes