### PR TITLE
Minor Makefile and man page fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ test:
 		cd /yadm && \
 		py.test -v $(testargs); \
 	else \
-		if command -v "docker-compose" &> /dev/null; then \
+		if command -v "docker-compose" > /dev/null 2>&1; then \
 			docker-compose run --rm testbed make test testargs="$(testargs)"; \
 		else \
 			echo "Sorry, this make test requires docker-compose to be installed."; \
@@ -197,7 +197,7 @@ sync-clock:
 
 .PHONY: require-docker
 require-docker:
-	@if ! command -v "docker" &> /dev/null; then \
+	@if ! command -v "docker" > /dev/null 2>&1; then \
 		echo "Sorry, this make target requires docker to be installed."; \
 		false; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,8 @@ test:
 	fi
 
 .PHONY: testhost
+testhost: version ?= HEAD
 testhost: require-docker
-	@version=HEAD
 	@rm -rf /tmp/testhost
 	@git show $(version):yadm > /tmp/testhost
 	@chmod a+x /tmp/testhost
@@ -117,8 +117,8 @@ testhost: require-docker
 		bash -l
 
 .PHONY: scripthost
+scripthost: version ?= HEAD
 scripthost: require-docker
-	@version=HEAD
 	@rm -rf /tmp/testhost
 	@git show $(version):yadm > /tmp/testhost
 	@chmod a+x /tmp/testhost

--- a/yadm.1
+++ b/yadm.1
@@ -704,7 +704,7 @@ Examples:
 .I whatever##template
 with the following content
 
-  {% if yadm.user == 'harvey' %}
+  {% if yadm.user == "harvey" %}
   config={{yadm.class}}-{{yadm.os}}
   {% else %}
   config=dev-whatever


### PR DESCRIPTION
### What does this PR do?

Fixes a few minor problems with the Makefile and man page.

### What issues does this PR fix or reference?

N/A

### Previous Behavior

Some of the make targets doesn't work on Debian and the example in the man page is incorrect.

### New Behavior

The make targets now work and the example is correct. I didn't recreated yadm.md as that caused more changes than just mine so I'll leave that to you.

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
