### PR TITLE
Add support for including files using the default template processor

### DIFF
--- a/yadm
+++ b/yadm
@@ -357,8 +357,13 @@ BEGIN {
   els           = "^{%" blank "*else" blank "*%}$"
   end           = "^{%" blank "*endif" blank "*%}$"
   skp           = "^{%" blank "*(if|else|endif)"
+  inc_start     = "^{%" blank "*include" blank "+\"?"
+  inc_end       = "\"?" blank "*%}$"
+  inc           = inc_start ".+" inc_end
   prt           = 1
+  err           = 0
 }
+END { exit err }
 { replace_vars() } # variable replacements
 $0 ~ vld, $0 ~ end {
   if ($0 ~ vld || $0 ~ end) prt=1;
@@ -370,7 +375,25 @@ $0 ~ vld, $0 ~ end {
   if ($0 ~ els || $0 ~ end) prt=1;
   if ($0 ~ skp) next;
 }
-{ if (prt) print }
+{ if (!prt) next }
+$0 ~ inc {
+  file = $0
+  sub(inc_start, "", file)
+  sub(inc_end, "", file)
+  sub(/^[^\/].*$/, source_dir "/&", file)
+
+  while ((res = getline <file) > 0) {
+    replace_vars()
+    print
+  }
+  if (res < 0) {
+    printf "%s:%d: error: could not read '%s'\n", FILENAME, NR, file | "cat 1>&2"
+    err = 1
+  }
+  close(file)
+  next
+}
+{ print }
 function replace_vars() {
   for (label in c) {
     gsub(("{{" blank "*yadm\\." label blank "*}}"), c[label])
@@ -396,8 +419,9 @@ EOF
     -v user="$local_user" \
     -v distro="$local_distro" \
     -v source="$input" \
+    -v source_dir="$(dirname "$input")" \
     "$awk_pgm" \
-    "$input" > "$temp_file"
+    "$input" > "$temp_file" || rm -f "$temp_file"
 
   if [ -f "$temp_file" ] ; then
     copy_perms "$input" "$temp_file"

--- a/yadm.1
+++ b/yadm.1
@@ -708,6 +708,7 @@ with the following content
   config={{yadm.class}}-{{yadm.os}}
   {% else %}
   config=dev-whatever
+  {% include "whatever.extra" %}
   {% endif %}
 
 would output a file named
@@ -716,9 +717,12 @@ with the following content if the user is "harvey":
 
   config=work-Linux
 
-and the following otherwise:
+and the following otherwise (if
+.I whatever.extra
+contains admin=false):
 
   config=dev-whatever
+  admin=false
 
 An equivalent Jinja template named
 .I whatever##template.j2
@@ -728,6 +732,7 @@ would look like:
   config={{YADM_CLASS}}-{{YADM_OS}}
   {% else -%}
   config=dev-whatever
+  {% include 'whatever.extra' %}
   {% endif -%}
 
 An equivalent ESH templated named
@@ -738,6 +743,7 @@ would look like:
   config=<%= $YADM_CLASS %>-<%= $YADM_OS %>
   <% else -%>
   config=dev-whatever
+  <%+ whatever.extra %>
   <% fi -%>
 
 .SH ENCRYPTION


### PR DESCRIPTION
### What does this PR do?

The syntax is '{% include "file" %}' where file is either an absolute path or a
path relative to the current template file's directory.

Variables in the included file will be replaced as for the main template. But
the included file can't include files itself or use if-else-endif directives.

### What issues does this PR fix or reference?

* #216
* #256
* #101 
* #222 

### Previous Behavior

To include external files in the template, one had to use either esh or jinja which required those to be installed.

### New Behavior

Now one can include files during template processing without using any external template engine.

### Have [tests][1] been written for this change?

Yes

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
