### PR TITLE
Add documentation for the template include directive

### DIFF
--- a/_docs/070_templates.md
+++ b/_docs/070_templates.md
@@ -106,6 +106,17 @@ This block is included for any other OS
 {% endif %}
 ```
 
+include
+: Content can be included from external files using the
+`{% include "filename" %}` syntax. The filename may include variables and
+should be either a path relative to the current template or an absolute
+path. The included file may itself also use variables, but if-else-endif or
+include directives are not supported. An example:
+
+```jinja
+{% include "extra/config.{{ yadm.os }}" %}
+```
+
 {% endraw %}
 
 [envtpl]: https://github.com/andreasjansson/envtpl


### PR DESCRIPTION
### What does this PR do?

Adds documentation for the include directive added in #255.

### What issues does this PR fix or reference?

* #255 
* #216 

### Previous Behavior

N/A

### New Behavior

The include directive is now documented.

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
