### PR TITLE
Add support for the extension "condition"

### DIFF
--- a/test/test_alt.py
+++ b/test/test_alt.py
@@ -81,6 +81,7 @@ def test_relative_link(runner, paths, yadm_alt):
 @pytest.mark.usefixtures('ds1_copy')
 @pytest.mark.parametrize('suffix', [
     '##default',
+    '##default,e.txt', '##default,extension.txt',
     '##o.$tst_sys', '##os.$tst_sys',
     '##d.$tst_distro', '##distro.$tst_distro',
     '##c.$tst_class', '##class.$tst_class',

--- a/yadm
+++ b/yadm
@@ -175,6 +175,10 @@ function score_file() {
     label=${field%%.*}
     value=${field#*.}
     [ "$field" = "$label" ] && value="" # when .value is omitted
+    # extension isn't a condition and doesn't affect the score
+    if [[ "$label" =~ ^(e|extension)$ ]]; then
+      continue
+    fi
     score=$((score + 1000))
     # default condition
     if [[ "$label" =~ ^(default)$ ]]; then

--- a/yadm.1
+++ b/yadm.1
@@ -526,6 +526,11 @@ and trimming off any domain.
 .TP
 .B default
 Valid when no other alternate is valid.
+.TP
+.BR extension , " e
+A special "condition" that doesn't affect the selection process. Its purpose is
+instead to allow the alternate file to end with a certain extension to
+e.g. make editors highlight the content properly.
 .LP
 
 .BR NOTE :


### PR DESCRIPTION
### What does this PR do?

Add support for the extension condition that doesn't affect the selection process and is only supported to support syntax highlighting and language detection for alt files.

### What issues does this PR fix or reference?

* #239 

### Previous Behavior

N/A

### New Behavior

It's possible to use e.g. `##default,e.rb` to give the file the `.rb` extension and thus have the editor highlight the content properly.

### Have [tests][1] been written for this change?

Yes (a minor one)

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
