### PR TITLE
Add documentation for extension condition (and minor fixes)

### DIFF
--- a/_docs/060_alternates.md
+++ b/_docs/060_alternates.md
@@ -32,7 +32,7 @@ be omitted. Most attributes can be abbreviated as a single letter.
 | `distro`, `d` | Valid if the value matches the distro. Distro is calculated by running <code>lsb_release&nbsp;&#8209;si</code> or inspecting <code>/etc/os-release</code> |
 | `os`, `o` | Valid if the value matches the OS. OS is calculated by running <code>uname&nbsp;&#8209;s</code>. <sup>*</sup> |
 | `class`, `c` | Valid if the value matches the local.class configuration. Class must be manually set using <code>yadm&nbsp;config&nbsp;local.class&nbsp;&lt;class&gt;</code>. |
-| `hostname`, `h` | Valid if the value matches the short hostname. Hostname is calculated by running `hostname`, and trimming off any domain. |
+| `hostname`, `h` | Valid if the value matches the short hostname. Hostname is calculated by running <code>uname&nbsp;&#8209;n</code>, and trimming off any domain. |
 | `default` | Valid when no other alternate is valid. |
 | `extension`, `e` | A special "condition" that doesn't affect the selection process. Its purpose is instead to allow the alternate file to end with a certain extension to e.g. make editors highlight the content properly. |
 

--- a/_docs/060_alternates.md
+++ b/_docs/060_alternates.md
@@ -27,13 +27,13 @@ be omitted. Most attributes can be abbreviated as a single letter.
 
 | Attribute | Meaning |
 | - | - |
-| `template`, `t` | Valid when the value matches a supported template processor. See the [Templates](/docs/templates) section for more details.|
+| `template`, `t` | Valid when the value matches a supported template processor. See the [Templates](/docs/templates) section for more details. |
 | `user`, `u` | Valid if the value matches the current user. Current user is calculated by running <code>id&nbsp;&#8209;u&nbsp;&#8209;n</code>. |
 | `distro`, `d` | Valid if the value matches the distro. Distro is calculated by running <code>lsb_release&nbsp;&#8209;si</code> or inspecting <code>/etc/os-release</code> |
 | `os`, `o` | Valid if the value matches the OS. OS is calculated by running <code>uname&nbsp;&#8209;s</code>. <sup>*</sup> |
 | `class`, `c` | Valid if the value matches the local.class configuration. Class must be manually set using <code>yadm&nbsp;config&nbsp;local.class&nbsp;&lt;class&gt;</code>. |
-|`hostname`, `h`|Valid if the value matches the short hostname. Hostname is calculated by running `hostname`, and trimming off any domain.|
-|`default`|Valid when no other alternate is valid.|
+| `hostname`, `h` | Valid if the value matches the short hostname. Hostname is calculated by running `hostname`, and trimming off any domain. |
+| `default` | Valid when no other alternate is valid. |
 
 <sub><sup>*
 The OS for "Windows Subsystem for Linux" is reported as "WSL", even though uname identifies as "Linux".

--- a/_docs/060_alternates.md
+++ b/_docs/060_alternates.md
@@ -34,6 +34,7 @@ be omitted. Most attributes can be abbreviated as a single letter.
 | `class`, `c` | Valid if the value matches the local.class configuration. Class must be manually set using <code>yadm&nbsp;config&nbsp;local.class&nbsp;&lt;class&gt;</code>. |
 | `hostname`, `h` | Valid if the value matches the short hostname. Hostname is calculated by running `hostname`, and trimming off any domain. |
 | `default` | Valid when no other alternate is valid. |
+| `extension`, `e` | A special "condition" that doesn't affect the selection process. Its purpose is instead to allow the alternate file to end with a certain extension to e.g. make editors highlight the content properly. |
 
 <sub><sup>*
 The OS for "Windows Subsystem for Linux" is reported as "WSL", even though uname identifies as "Linux".


### PR DESCRIPTION
### What does this PR do?

Add documentation for the extension condition added in #257 and fix an error in the hostname condition.

### What issues does this PR fix or reference?

* #257 

### Previous Behavior

N/A

### New Behavior

The condition is now documented and the command used to determine hostname is correct.

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
