### PR TITLE
Fix typos in 070_templates.md

### DIFF
--- a/_docs/070_templates.md
+++ b/_docs/070_templates.md
@@ -41,7 +41,7 @@ When template processors run, they will be provided the following set of data.
 | -                  | -               | -                          | -                                              |
 | `yadm.class`       | `YADM_CLASS`    | Locally defined yadm class | <code>yadm&nbsp;config&nbsp;local.class</code> |
 | `yadm.distro`      | `YADM_DISTRO`   | Distribution               | <code>lsb_release&nbsp;&#8209;si</code><br/>or <code>/etc/os-release</code> |
-| `yadm.hostname`    | `YADM_HOSTNAME` | Hostname                   | `hostname` (without domain)                    |
+| `yadm.hostname`    | `YADM_HOSTNAME` | Hostname                   | <code>uname&nbsp;&#8209;n</code> (without domain)                    |
 | `yadm.os`          | `YADM_OS`       | Operating system           | <code>uname&nbsp;&#8209;s</code> <sup>*</sup>  |
 | `yadm.user`        | `YADM_USER`     | Current user               | <code>id&nbsp;&#8209;u&nbsp;&#8209;n</code>    |
 | `yadm.source`      | `YADM_SOURCE`   | Template filename          | (fully qualified path)                         |
@@ -64,7 +64,7 @@ detailed in the section below.
 esh
 : [esh][esh] is a template processor written in POSIX compliant shell. It allows
 executing shell commands within templates.  This  can  be used  to reference
-your own configurations within templates, for example:
+your own configurations within templates.
 
 j2cli
 : [j2cli][j2cli] (or `j2`) is a Python-based Jinja2 template processor. This


### PR DESCRIPTION
See https://github.com/TheLocehiliosan/yadm/blob/3ddea208535be182af8cb53095d237bce55267f8/yadm#L588

### What does this PR do?

Fix typos

### What issues does this PR fix or reference?

None.

### Previous Behavior

n/a

### New Behavior

n/a

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
