### PR TITLE
 print help and version early

### DIFF
--- a/yadm
+++ b/yadm
@@ -1404,9 +1404,6 @@ function process_global_args() {
       -V|--version)
         version
       ;;
-      -h|--help)
-        help
-      ;;
       -Y|--yadm-dir) # override the standard YADM_DIR
         if [[ ! "$2" =~ ^/ ]] ; then
           error_out "You must specify a fully qualified yadm directory"

--- a/yadm
+++ b/yadm
@@ -1401,6 +1401,12 @@ function process_global_args() {
   while [[ $# -gt 0 ]] ; do
     key="$1"
     case $key in
+      -V|--version)
+        version
+      ;;
+      -h|--help)
+        help
+      ;;
       -Y|--yadm-dir) # override the standard YADM_DIR
         if [[ ! "$2" =~ ^/ ]] ; then
           error_out "You must specify a fully qualified yadm directory"


### PR DESCRIPTION
### What does this PR do?

Causes version messages to be printed before `require_repo` and the like.

### What issues does this PR fix or reference?

closes #267

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes
