### PR TITLE
Issue legacy path warnings to stderr

### DIFF
--- a/test/test_unit_issue_legacy_path_warning.py
+++ b/test/test_unit_issue_legacy_path_warning.py
@@ -34,8 +34,8 @@ def test_legacy_warning(tmpdir, runner, yadm, upgrade, override, legacy_path):
     """
     run = runner(command=['bash'], inp=script)
     assert run.success
-    assert run.err == ''
+    assert run.out == ''
     if legacy_path and (not upgrade) and (not override):
-        assert 'Legacy paths have been detected' in run.out
+        assert 'Legacy paths have been detected' in run.err
     else:
-        assert 'Legacy paths have been detected' not in run.out
+        assert 'Legacy paths have been detected' not in run.err

--- a/yadm
+++ b/yadm
@@ -1506,7 +1506,7 @@ function issue_legacy_path_warning() {
     path_list="$path_list    * $legacy_path"$'\n'
   done
 
-  cat <<EOF
+  cat <<EOF >&2
 
 **WARNING**
   Legacy paths have been detected.


### PR DESCRIPTION
### What does this PR do?

Output legacy path warnings to stderr instead of stdout to make it possible to filter it in e.g. the bash completion.

### What issues does this PR fix or reference?

N/A

### Previous Behavior

The warning would be printed on stdout together with the requested information (in the case of introspect).

### New Behavior

Now it's printed to stderr.

### Have [tests][1] been written for this change?

Existing ones have been updated.

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
