### PR TITLE
Add _yadm symlink to ease zsh completion usage from source

### DIFF
--- a/completion/zsh/_yadm
+++ b/completion/zsh/_yadm
@@ -1,0 +1,1 @@
+../yadm.zsh_completion


### PR DESCRIPTION
### What does this PR do?

This is a variant of #238 that only adds a zsh/_yadm symlink to make it easier to use the zsh completion directly from source.

### What issues does this PR fix or reference?

### Previous Behavior

One had to create the symlink manually or rename the file.

### New Behavior

One can just do `fpath=(/path/yadm/completion/zsh $fpath); compinit` and it works as expected. Nothing should break for existing setups.

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
