### PR TITLE
Simplify and shrink docker setup

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -207,7 +207,7 @@ these principles when making changes.
     ```
 
 4. Verify you can run the test harness. _(This will require dependencies:
-   `make`, `docker`, and `docker-compose`)_.
+   `make` and `docker`)_.
 
     ```text
     $ make test

--- a/Makefile
+++ b/Makefile
@@ -93,12 +93,8 @@ test:
 		cd /yadm && \
 		py.test -v $(testargs); \
 	else \
-		if command -v "docker-compose" > /dev/null 2>&1; then \
-			docker-compose run --rm testbed make test testargs="$(testargs)"; \
-		else \
-			echo "Sorry, this make test requires docker-compose to be installed."; \
-			false; \
-		fi \
+		$(MAKE) -s require-docker && \
+		docker run --rm -it -v "$(CURDIR):/yadm:ro" $(IMAGE) make test testargs="$(testargs)"; \
 	fi
 
 .PHONY: testhost

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,0 @@
----
-version: '3'
-services:
-  testbed:
-    volumes:
-      - .:/yadm:ro
-    image: yadm/testbed:2020-12-21

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -56,6 +56,11 @@ RUN mkdir /yadm \
   && echo "\t@echo 'Try using a docker parameter like -v \"\$\$PWD:/yadm:ro\"'" >> /yadm/Makefile \
   && echo "\t@false" >> /yadm/Makefile
 
+# Include released versions of yadm to test upgrades
+ADD https://raw.githubusercontent.com/TheLocehiliosan/yadm/1.12.0/yadm /usr/local/bin/yadm-1.12.0
+ADD https://raw.githubusercontent.com/TheLocehiliosan/yadm/2.5.0/yadm /usr/local/bin/yadm-2.5.0
+RUN chmod +x /usr/local/bin/yadm-*
+
 # /yadm will be the work directory for all tests
 # docker commands should mount the local yadm project as /yadm
 WORKDIR /yadm

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -61,6 +61,10 @@ ADD https://raw.githubusercontent.com/TheLocehiliosan/yadm/1.12.0/yadm /usr/loca
 ADD https://raw.githubusercontent.com/TheLocehiliosan/yadm/2.5.0/yadm /usr/local/bin/yadm-2.5.0
 RUN chmod +x /usr/local/bin/yadm-*
 
+# Configure git to make it easier to test yadm manually
+RUN git config --system user.email "test@yadm.io" \
+  && git config --system user.name "Yadm Test"
+
 # /yadm will be the work directory for all tests
 # docker commands should mount the local yadm project as /yadm
 WORKDIR /yadm

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,12 +1,29 @@
 FROM ubuntu:18.04
 MAINTAINER Tim Byrne <sultan@locehilios.com>
 
-# No input during build
-ENV DEBIAN_FRONTEND noninteractive
+# Shellcheck and esh versions
+ARG SC_VER=0.7.1
+ARG ESH_VER=0.3.0
 
-# UTF8 locale
-RUN apt-get update && apt-get install -y locales
-RUN locale-gen en_US.UTF-8
+# Install prerequisites and configure UTF-8 locale
+RUN \
+  echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
+  && apt-get update \
+  && DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-recommends \
+    expect \
+    git \
+    gnupg \
+    locales \
+    lsb-release \
+    make \
+    man \
+    python3-pip \
+    vim-tiny \
+    xz-utils \
+  && rm -rf /var/lib/apt/lists/* \
+  && update-locale LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # Convenience settings for the testbed's root account
@@ -15,43 +32,33 @@ RUN echo 'set -o vi' >> /root/.bashrc
 # Create a flag to identify when running inside the yadm testbed
 RUN touch /.yadmtestbed
 
-# Install prerequisites
-RUN \
-  apt-get update && \
-  apt-get install -y \
-    curl \
-    expect \
-    git \
-    gnupg \
-    lsb-release \
-    make \
-    man \
-    python3-pip \
-    vim \
-  && rm -rf /var/lib/apt/lists/*;
+# Install shellcheck
+ADD https://github.com/koalaman/shellcheck/releases/download/v$SC_VER/shellcheck-v$SC_VER.linux.x86_64.tar.xz /opt
+RUN cd /opt \
+  && tar xf shellcheck-v$SC_VER.linux.x86_64.tar.xz \
+  && rm -f shellcheck-v$SC_VER.linux.x86_64.tar.xz \
+  && ln -s /opt/shellcheck-v$SC_VER/shellcheck /usr/local/bin
 
-ARG SC_VER=0.7.1
-RUN \
-  curl -fLo - \
-  https://github.com/koalaman/shellcheck/releases/download/v$SC_VER/shellcheck-v$SC_VER.linux.x86_64.tar.xz | \
-  tar -xJv && \
-  mv shellcheck-v$SC_VER/shellcheck /usr/bin && \
-  rm -rf shellcheck-v$SC_VER
-
+# Upgrade pip3 and install requirements
 COPY test/requirements.txt /tmp/requirements.txt
-RUN pip3 install --upgrade pip setuptools
-RUN pip3 install --upgrade -r /tmp/requirements.txt
+RUN python3 -m pip install --upgrade pip setuptools \
+  && python3 -m pip install --upgrade -r /tmp/requirements.txt \
+  && rm -f /tmp/requirements
 
-RUN \
-  curl https://raw.githubusercontent.com/jirutka/esh/v0.3.0/esh > /usr/local/bin/esh && \
-  chmod +x /usr/local/bin/esh
+# Install esh
+ADD https://raw.githubusercontent.com/jirutka/esh/v$ESH_VER/esh /usr/local/bin
+RUN chmod +x /usr/local/bin/esh
+
+# Create workdir and dummy Makefile to be used if no /yadm volume is mounted
+RUN mkdir /yadm \
+  && echo "test:" > /yadm/Makefile \
+  && echo "\t@echo 'The yadm project must be mounted at /yadm'" >> /yadm/Makefile \
+  && echo "\t@echo 'Try using a docker parameter like -v \"\$\$PWD:/yadm:ro\"'" >> /yadm/Makefile \
+  && echo "\t@false" >> /yadm/Makefile
 
 # /yadm will be the work directory for all tests
 # docker commands should mount the local yadm project as /yadm
 WORKDIR /yadm
-
-# Create a Makefile to be used if no /yadm volume is mounted
-RUN echo "test:\n\t@echo 'The yadm project must be mounted at /yadm'\n\t@echo 'Try using a docker parameter like -v \"\$\$PWD:/yadm:ro\"'\n\t@false" > /yadm/Makefile
 
 # By default, run all tests defined
 CMD make test

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,5 +2,5 @@ envtpl
 flake8==3.8.4
 j2cli
 pylint==2.6.0
-pytest==6.1.2
+pytest==6.2.1
 yamllint==1.25.0


### PR DESCRIPTION
### What does this PR do?

* Remove the requirement on docker-compose for running tests.
* Shrink the docker image with ~380 MB (no apt recommendations + some other minor changes).

### What issues does this PR fix or reference?

None.

### Previous Behavior

A bigger than necessary docker image.

### New Behavior

The image is now 251 MB instead of 637 MB.

### Have [tests][1] been written for this change?

No, but the existing tests pass on the new image.

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
