### PR TITLE
Fix contrib make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,8 +172,9 @@ yadm.md: yadm.1
 	@groff -man -Tascii ./yadm.1 | col -bx | sed 's/^[A-Z]/## &/g' | sed '/yadm(1)/d' > yadm.md
 
 .PHONY: contrib
+contrib: SHELL = /bin/bash
 contrib:
-	@echo "CONTRIBUTORS\n" > CONTRIBUTORS
+	@echo -e "CONTRIBUTORS\n" > CONTRIBUTORS
 	@IFS=$$'\n'; for author in $$(git shortlog -ns master gh-pages develop dev-pages | cut -f2); do \
 		git log master gh-pages develop dev-pages \
 			--author="$$author" --format=tformat: --numstat | \


### PR DESCRIPTION
### What does this PR do?

Set shell explicitly as it doesn't work with the default shell on Debian.

### What issues does this PR fix or reference?

None

### Previous Behavior

`make contrib` failed with strange errors when run on my Debian machine.

### New Behavior

Now `make contrib` works as expected.

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
