### PR TITLE
Remove -d from zsh completion

### DIFF
--- a/completion/zsh/_yadm
+++ b/completion/zsh/_yadm
@@ -122,7 +122,6 @@ _yadm() {
       '--yadm-encrypt[override the standard encrypt path]: :_files -/' \
       '--yadm-archive[override the standard archive path]: :_files -/' \
       '--yadm-bootstrap[override the standard bootstrap path]: :_files' \
-      '-d[print debug traces]' \
       '--help[display yadm help information]' \
       '--version[show yadm version]' \
       '(-): :->command' \


### PR DESCRIPTION
### What does this PR do?

#274 added -d as a possible global yadm flag. But that doesn't work, so instead remove it.

### What issues does this PR fix or reference?

Fixes error in #274.

### Previous Behavior

An user using zsh could try to use -d in the wrong place, making yadm fail.

### New Behavior

Now -d isn't suggested as a completion any more.

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
