### PR TITLE
Make yadm enter work with zsh and tramp

### DIFF
--- a/yadm
+++ b/yadm
@@ -1004,13 +1004,17 @@ function enter() {
   require_shell
   require_repo
 
-  shell_opts=""
-  shell_path=""
+  local -a shell_opts
+  local shell_path=""
   if [[ "$SHELL" =~ bash$ ]]; then
-    shell_opts="--norc"
+    shell_opts=("--norc")
     shell_path="\w"
   elif [[ "$SHELL" =~ [cz]sh$ ]]; then
-    shell_opts="-f"
+    shell_opts=("-f")
+    if [[ "$SHELL" =~ zsh$ && "$TERM" = "dumb" ]]; then
+      # Disable ZLE for tramp
+      shell_opts+=("--no-zle")
+    fi
     shell_path="%~"
   fi
 
@@ -1025,7 +1029,7 @@ function enter() {
   [ "${#shell_cmd[@]}" -eq 0 ] && echo "Entering yadm repo"
 
   yadm_prompt="yadm shell ($YADM_REPO) $shell_path > "
-  PROMPT="$yadm_prompt" PS1="$yadm_prompt" "$SHELL" $shell_opts "${shell_cmd[@]}"
+  PROMPT="$yadm_prompt" PS1="$yadm_prompt" "$SHELL" "${shell_opts[@]}" "${shell_cmd[@]}"
   return_code="$?"
 
   if [ "${#shell_cmd[@]}" -eq 0 ]; then

--- a/yadm.1
+++ b/yadm.1
@@ -208,8 +208,7 @@ Emacs Tramp and Magit can manage files by using this configuration:
 .RE
 
 .RS
-With this config, use (magit-status "/yadm::"). If you find issue with Emacs 27 and zsh,
-trying running (setenv "SHELL" "/bin/bash").
+With this config, use (magit-status "/yadm::").
 .RE
 .TP
 .BI git-crypt " options


### PR DESCRIPTION
### What does this PR do?

zle must be disabled when using tramp, otherwise it doesn't work.

### What issues does this PR fix or reference?

* Related to #280.

### Previous Behavior

emacs hanged when you tried to use magit-status with yadm.

### New Behavior

Now it seems to work.

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
