### PR TITLE
Update testenv

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Tests
-        run: >-
-          docker run -t --rm
-          -v "$PWD:/yadm:ro"
-          yadm/testbed:2020-12-29
+        run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .jekyll-metadata
 .pytest_cache
 .sass-cache
+.testyadm
 _site
 testenv

--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,10 @@ testenv:
 	python3 -m venv --clear testenv
 	testenv/bin/pip3 install --upgrade pip setuptools
 	testenv/bin/pip3 install --upgrade -r test/requirements.txt;
+	@for v in $$(sed -rn -e 's:.*/yadm-([0-9.]+)$$:\1:p' test/Dockerfile); do \
+		git show $$v:yadm > testenv/bin/yadm-$$v; \
+		chmod +x testenv/bin/yadm-$$v; \
+	done
 	@echo
 	@echo 'To activate this test environment type:'
 	@echo '  source testenv/bin/activate'

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ usage:
 # Make it possible to run make specifying a py.test test file
 .PHONY: $(PYTESTS)
 $(PYTESTS):
-	@$(MAKE) test testargs="-k $@ $(testargs)"
+	@$(MAKE) test testargs="$@ $(testargs)"
 %.py:
 	@$(MAKE) test testargs="-k $@ $(testargs)"
 

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,11 @@ test:
 		py.test -v $(testargs); \
 	else \
 		$(MAKE) -s require-docker && \
-		docker run --rm -it -v "$(CURDIR):/yadm:ro" $(IMAGE) make test testargs="$(testargs)"; \
+		docker run \
+			--rm -t$(shell test -t 0 && echo i) \
+			-v "$(CURDIR):/yadm:ro" \
+			$(IMAGE) \
+			make test testargs="$(testargs)"; \
 	fi
 
 .PHONY: .testyadm

--- a/Makefile
+++ b/Makefile
@@ -26,14 +26,15 @@ usage:
 	@echo '      HEAD revision of yadm will be used unless "version" is'
 	@echo '      specified. "version" can be set to any commit, branch, tag, etc.'
 	@echo '      The targeted "version" will be retrieved from the repo, and'
-	@echo '      linked into the container as a local volume.'
+	@echo '      linked into the container as a local volume. Setting version to'
+	@echo '      "local" uses yadm from the current working tree.'
 	@echo
 	@echo '  make scripthost [version=VERSION]'
 	@echo '    - Create an ephemeral container for demonstrating a bug. After'
 	@echo '      exiting the shell, a log of the commands used to illustrate the'
 	@echo '      problem will be written to the file "script.txt". This file can'
 	@echo '      be useful to developers to make a repeatable test for the'
-	@echo '      problem.'
+	@echo '      problem. The version parameter works as for "testhost" above.'
 	@echo
 	@echo 'LINTING'
 	@echo


### PR DESCRIPTION
### What does this PR do?

* Make `version=local` work for scripthost target (as it does for testhost).
* Run `make test` in github workflow.
* Include yadm versions in testenv similar to the docker image. So that any tests that uses old versions in the docker image will work also with the testenv.

### What issues does this PR fix or reference?

N/A

### Previous Behavior

N/A

### New Behavior

See above.

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
