### PR TITLE
Use local version of yadm by default (in testhost/scripthost)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,10 @@ usage:
 	@echo
 	@echo '  make testhost [version=VERSION]'
 	@echo '    - Create an ephemeral container for doing adhoc yadm testing. The'
-	@echo '      HEAD revision of yadm will be used unless "version" is'
+	@echo '      working copy version of yadm will be used unless "version" is'
 	@echo '      specified. "version" can be set to any commit, branch, tag, etc.'
 	@echo '      The targeted "version" will be retrieved from the repo, and'
-	@echo '      linked into the container as a local volume. Setting version to'
-	@echo '      "local" uses yadm from the current working tree.'
+	@echo '      linked into the container as a local volume.'
 	@echo
 	@echo '  make scripthost [version=VERSION]'
 	@echo '    - Create an ephemeral container for demonstrating a bug. After'
@@ -103,13 +102,15 @@ test:
 	fi
 
 .PHONY: .testyadm
-.testyadm: version ?= HEAD
+.testyadm: version ?= local
 .testyadm:
-	@echo "Using yadm version=\"$(version)\""
+	@rm -f $@
 	@if [ "$(version)" = "local" ]; then \
-		cp -f yadm $@; \
+		ln -sf yadm $@; \
+		echo "Using local yadm ($$(git describe --tags --dirty))"; \
 	else \
 		git show $(version):yadm > $@; \
+		echo "Using yadm version $$(git describe --tags $(version))"; \
 	fi
 	@chmod a+x $@
 


### PR DESCRIPTION
### What does this PR do?

While developing you most likely want to use the local version of yadm, so make that the default. Also symlink instead of copy in that case to make local changes visible on the testhost.

### What issues does this PR fix or reference?

None.

### Previous Behavior

You (or I) would run `make testhost` and perform some testing. After a while you'd realize that it didn't work as expected because you'd forgotten `version=local`...

### New Behavior

Makes development easier.

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
