### PR TITLE
Change handling of submodules at upgrade

### DIFF
--- a/yadm
+++ b/yadm
@@ -122,7 +122,7 @@ function main() {
           -d) # used by all commands
             DEBUG="YES"
           ;;
-          -f) # used by init() and clone()
+          -f) # used by init(), clone() and upgrade()
             FORCE="YES"
           ;;
           -l) # used by decrypt()
@@ -1296,7 +1296,7 @@ function perms() {
 function upgrade() {
 
   local actions_performed=0
-  local repo_moved=0
+  local -a submodules
   local repo_updates=0
 
   [[ -n "${YADM_OVERRIDE_REPO}${YADM_OVERRIDE_ARCHIVE}" || "$YADM_DATA" = "$YADM_DIR" ]] && \
@@ -1315,8 +1315,27 @@ function upgrade() {
       error_out "Unable to upgrade. '$YADM_REPO' already exists. Refusing to overwrite it."
     else
       actions_performed=1
-      repo_moved=1
       echo "Moving $LEGACY_REPO to $YADM_REPO"
+
+      export GIT_DIR="$LEGACY_REPO"
+
+      # Must absorb git dirs, otherwise deinit below will fail for modules that have
+      # been cloned first and then added as a submodule.
+      "$GIT_PROGRAM" submodule absorbgitdirs
+
+      while read -r sha submodule rest; do
+          if [[ "$sha" = -* ]]; then
+              continue
+          fi
+          "$GIT_PROGRAM" -C "$YADM_WORK" submodule deinit ${FORCE:+-f} -- "$submodule" || {
+              for other in "${submodules[@]}"; do
+                  "$GIT_PROGRAM" -C "$YADM_WORK" submodule update --init --recursive -- "$other"
+              done
+              error_out "Unable to upgrade. Could not deinit submodule $submodule"
+          }
+          submodules+=("$submodule")
+      done < <("$GIT_PROGRAM" -C "$YADM_WORK" submodule status)
+
       assert_parent "$YADM_REPO"
       mv "$LEGACY_REPO" "$YADM_REPO"
     fi
@@ -1366,13 +1385,9 @@ function upgrade() {
   done
 
   # handle submodules, which need to be reinitialized
-  if [ "$repo_moved" -ne 0 ]; then
-    cd_work "Upgrade submodules"
-    if "$GIT_PROGRAM" ls-files --error-unmatch .gitmodules &> /dev/null; then
-      "$GIT_PROGRAM" submodule deinit -f .
-      "$GIT_PROGRAM" submodule update --init --recursive
-    fi
-  fi
+  for submodule in "${submodules[@]}"; do
+      "$GIT_PROGRAM" -C "$YADM_WORK" submodule update --init --recursive -- "$submodule"
+  done
 
   [ "$actions_performed" -eq 0 ] && \
     echo "No legacy paths found. Upgrade is not necessary"
@@ -1610,7 +1625,7 @@ function issue_legacy_path_warning() {
 
   To remove this warning do one of the following:
     * Run "yadm upgrade" to move the yadm data to the new paths. (RECOMMENDED)
-    * Manually move yadm data to new default paths.
+    * Manually move yadm data to new default paths and reinit any submodules.
     * Specify your preferred paths with --yadm-data and --yadm-archive each execution.
 
   Legacy paths detected:


### PR DESCRIPTION
### What does this PR do?

Changes how submodules are handled during upgrade.

### What issues does this PR fix or reference?

* #285 

### Previous Behavior

Upgrade would deinit submodules after moving the repo and then initialize them all. There are a couple of issues with this:
* As `-f` is used during deinit, any local changes in the submodule would be lost.
* The upgrade completes even if deinit fails (e.g. as seen in #285) and can leave the repo in an inconsistent state.
* All submodules are initialized, even if they weren't initialized before the upgrade (minor issue).

### New Behavior

* The first step is now `submodule absorbgitdirs`. This makes sure that `submodule deinit` will not fail for modules that were cloned before being added.
* Then `submodule deinit` is called for each submodule that's initialized. If an error happens the deinit is undone and upgrade fails.
* After all submodules are deinit'ed, the upgrade continues as before.
* Finally, submodules that were deinitialized in step 2 are re-initialized.

### Have [tests][1] been written for this change?

Yes, see #284.

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
