### PR TITLE
Error on stderr

### DIFF
--- a/test/test_bootstrap.py
+++ b/test/test_bootstrap.py
@@ -27,5 +27,9 @@ def test_bootstrap(
         paths.bootstrap.chmod(0o775)
     run = runner(command=yadm_cmd('bootstrap'))
     assert run.code == code
-    assert run.err == ''
-    assert expect in run.out
+    if exists and executable:
+        assert run.err == ''
+        assert expect in run.out
+    else:
+        assert expect in run.err
+        assert run.out == ''

--- a/test/test_clean.py
+++ b/test/test_clean.py
@@ -7,5 +7,5 @@ def test_clean_command(runner, yadm_cmd):
     # do nothing, this is a dangerous Git command when managing dot files
     # report the command as disabled and exit as a failure
     assert run.failure
-    assert run.err == ''
-    assert 'disabled' in run.out
+    assert run.out == ''
+    assert 'disabled' in run.err

--- a/test/test_clone.py
+++ b/test/test_clone.py
@@ -58,14 +58,14 @@ def test_clone(
     if not good_remote:
         # clone should fail
         assert run.failure
-        assert run.err != ''
-        assert 'Unable to fetch origin' in run.out
+        assert run.out != ''
+        assert 'Unable to fetch origin' in run.err
         assert not paths.repo.exists()
     elif repo_exists and not force:
         # can't overwrite data
         assert run.failure
-        assert run.err == ''
-        assert 'Git repo already exists' in run.out
+        assert run.out == ''
+        assert 'Git repo already exists' in run.err
     else:
         # clone should succeed, and repo should be configured properly
         assert successful_clone(run, paths, repo_config)
@@ -297,8 +297,8 @@ def test_alternate_branch(runner, paths, yadm_cmd, repo_config, branch):
 
     if branch == 'invalid':
         assert run.failure
-        assert 'ERROR: Clone failed' in run.out
-        assert f"'origin/{branch}' does not exist in {remote_url}" in run.out
+        assert 'ERROR: Clone failed' in run.err
+        assert f"'origin/{branch}' does not exist in {remote_url}" in run.err
     else:
         assert successful_clone(run, paths, repo_config)
 
@@ -344,8 +344,8 @@ def test_no_repo(runner, yadm_cmd, ):
     """Test cloning without specifying a repo"""
     run = runner(command=yadm_cmd('clone'))
     assert run.failure
-    assert run.err == ''
-    assert 'ERROR: No repository provided' in run.out
+    assert run.out == ''
+    assert 'ERROR: No repository provided' in run.err
 
 
 def verify_head(paths, branch):

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -212,7 +212,7 @@ def test_symmetric_encrypt(
         assert run.err == ''
 
     if missing_encrypt:
-        assert 'does not exist' in run.out
+        assert 'does not exist' in run.err
     elif bad_phrase:
         assert 'Invalid passphrase' in run.err
     else:
@@ -313,7 +313,7 @@ def test_asymmetric_encrypt(
             runner, gnupg, paths.archive, encrypt_targets)
     else:
         assert run.failure
-        assert 'Unable to write' in run.out
+        assert 'Unable to write' in run.out if expect else run.err
 
     if ask:
         assert 'Enter the user ID' in run.out
@@ -380,7 +380,7 @@ def test_asymmetric_decrypt(
                 assert paths.work.join(filename).read() == filename
     else:
         assert run.failure
-        assert 'Unable to extract encrypted files' in run.out
+        assert 'Unable to extract encrypted files' in run.err
 
 
 @pytest.mark.parametrize(

--- a/test/test_enter.py
+++ b/test/test_enter.py
@@ -35,13 +35,13 @@ def test_enter(runner, yadm_cmd, paths, shell, success):
 
     run = runner(command=yadm_cmd('enter'), env=env)
     assert run.success == success
-    assert run.err == ''
     prompt = f'yadm shell ({paths.repo})'
     if success:
         assert run.out.startswith('Entering yadm repo')
         assert run.out.rstrip().endswith('Leaving yadm repo')
-    if not success:
-        assert 'does not refer to an executable' in run.out
+        assert run.err == ''
+    else:
+        assert 'does not refer to an executable' in run.err
     if 'env' in shell:
         assert f'GIT_DIR={paths.repo}' in run.out
         assert f'GIT_WORK_TREE={paths.work}' in run.out

--- a/test/test_ext_crypt.py
+++ b/test/test_ext_crypt.py
@@ -42,7 +42,7 @@ def test_ext_encryption(runner, yadm, paths, tmpdir, crypt, cmd, var):
         else:
             assert run.success
         assert run.out.strip() == 'ext-crypt ran'
+        assert run.err == ''
     else:
         assert run.failure
-        assert f"command '{pgm}' cannot be located" in run.out
-    assert run.err == ''
+        assert f"command '{pgm}' cannot be located" in run.err

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -52,15 +52,15 @@ def test_init(
 
     # run init
     run = runner(yadm_cmd(*args), env={'HOME': home})
-    assert run.err == ''
 
     if repo_present and not force:
         assert run.failure
-        assert 'repo already exists' in run.out
+        assert 'repo already exists' in run.err
         assert old_repo.isfile(), 'Missing original repo'
     else:
         assert run.success
         assert 'Initialized empty shared Git repository' in run.out
+        assert run.err == ''
 
         if repo_present:
             assert not old_repo.isfile(), 'Original repo still exists'

--- a/test/test_unit_configure_paths.py
+++ b/test/test_unit_configure_paths.py
@@ -85,6 +85,7 @@ def run_test(runner, paths, args, expected_matches, expected_code=0):
     """
     run = runner(command=['bash'], inp=script)
     assert run.code == expected_code
-    assert run.err == ''
+    assert run.success == (run.code == 0)
+    assert (run.err if run.success else run.out) == ''
     for match in expected_matches:
-        assert match in run.out
+        assert match in run.out if run.success else run.err

--- a/test/test_unit_encryption.py
+++ b/test/test_unit_encryption.py
@@ -51,14 +51,14 @@ def test_encrypt_decrypt(runner, paths, cipher, mode):
     """
     run = runner(command=['bash'], inp=script)
 
-    assert run.err == ''
     if cipher != 'bad':
         assert run.success
         assert run.out.startswith(cipher)
         assert str(paths.archive) in run.out
+        assert run.err == ''
     else:
         assert run.failure
-        assert 'Unknown cipher' in run.out
+        assert 'Unknown cipher' in run.err
 
 
 @pytest.mark.parametrize('condition', ['default', 'override'])

--- a/test/test_unit_set_local_alt_values.py
+++ b/test/test_unit_set_local_alt_values.py
@@ -67,6 +67,7 @@ def test_distro(runner, yadm):
 
     script = f"""
         YADM_TEST=1 source {yadm}
+        function config() {{ echo "$1"; }}
         function query_distro() {{ echo "testdistro"; }}
         set_local_alt_values
         echo "distro='$local_distro'"

--- a/test/test_unit_upgrade.py
+++ b/test/test_unit_upgrade.py
@@ -29,12 +29,11 @@ def test_upgrade_errors(tmpdir, runner, yadm, condition):
     """
     run = runner(command=['bash'], inp=script)
     assert run.failure
-    assert run.err == ''
-    assert 'Unable to upgrade' in run.out
+    assert 'Unable to upgrade' in run.err
     if condition in ['override', 'equal']:
-        assert 'Paths have been overridden' in run.out
-    if condition == 'existing_repo':
-        assert 'already exists' in run.out
+        assert 'Paths have been overridden' in run.err
+    elif condition == 'existing_repo':
+        assert 'already exists' in run.err
 
 
 @pytest.mark.parametrize(

--- a/test/test_unit_x_program.py
+++ b/test/test_unit_x_program.py
@@ -27,7 +27,8 @@ def test_x_program(
     # test require_[git,gpg]
     script = f"""
         YADM_TEST=1 source {paths.pgm}
-        YADM_CONFIG="{paths.config}"
+        YADM_OVERRIDE_CONFIG="{paths.config}"
+        configure_paths
         require_{program}
         echo ${program.upper()}_PROGRAM
     """

--- a/test/test_unit_x_program.py
+++ b/test/test_unit_x_program.py
@@ -34,7 +34,6 @@ def test_x_program(
     """
     run = runner(command=['bash'], inp=script)
     assert run.success == success
-    assert run.err == ''
 
     # [GIT,GPG]_PROGRAM set correctly
     if value == 'program':
@@ -44,4 +43,6 @@ def test_x_program(
 
     # error reported about bad config
     if match:
-        assert match in run.out
+        assert match in run.err
+    else:
+        assert run.err == ''

--- a/yadm
+++ b/yadm
@@ -1745,7 +1745,7 @@ function debug() {
 
 function error_out() {
 
-  echo_e "ERROR: $*"
+  echo_e "ERROR: $*" >&2
   exit_with_hook 1
 
 }


### PR DESCRIPTION
### What does this PR do?

Make `error_out` print the error to stderr to be able to run `yadm --yadm-data foo introspect repo` in zsh completion and get an empty result instead of getting the error about foo not being qualified.

### What issues does this PR fix or reference?

None

### Previous Behavior

An error was reported on stdout.

### New Behavior

An error is now reported on stderr.

### Have [tests][1] been written for this change?

Tests have been updated.

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
