### PR TITLE
Support passing relative paths to --yadm-*

### DIFF
--- a/test/test_init.py
+++ b/test/test_init.py
@@ -45,13 +45,18 @@ def test_init(
 
     # command args
     args = ['init']
+    cwd = None
     if alt_work:
-        args.extend(['-w', paths.work])
+        if force:
+            cwd = paths.work.dirname
+            args.extend(['-w', paths.work.basename])
+        else:
+            args.extend(['-w', paths.work])
     if force:
         args.append('-f')
 
     # run init
-    run = runner(yadm_cmd(*args), env={'HOME': home})
+    run = runner(yadm_cmd(*args), env={'HOME': home}, cwd=cwd)
 
     if repo_present and not force:
         assert run.failure

--- a/yadm
+++ b/yadm
@@ -130,10 +130,7 @@ function main() {
             [ "$YADM_COMMAND" = "config" ] && YADM_ARGS+=("$1")
           ;;
           -w) # used by init() and clone()
-            if [[ ! "$2" =~ ^/ ]] ; then
-              error_out "You must specify a fully qualified work tree"
-            fi
-            YADM_WORK="$2"
+            YADM_WORK="$(qualify_path "$2" "work tree")"
             shift
           ;;
           *) # any unhandled arguments
@@ -1495,52 +1492,31 @@ function process_global_args() {
     key="$1"
     case $key in
       -Y|--yadm-dir) # override the standard YADM_DIR
-        if [[ ! "$2" =~ ^/ ]] ; then
-          error_out "You must specify a fully qualified yadm directory"
-        fi
-        YADM_DIR="$2"
+        YADM_DIR="$(qualify_path "$2" "yadm")"
         shift
       ;;
       --yadm-data) # override the standard YADM_DATA
-        if [[ ! "$2" =~ ^/ ]] ; then
-          error_out "You must specify a fully qualified yadm data directory"
-        fi
-        YADM_DATA="$2"
+        YADM_DATA="$(qualify_path "$2" "data")"
         shift
       ;;
       --yadm-repo) # override the standard YADM_REPO
-        if [[ ! "$2" =~ ^/ ]] ; then
-          error_out "You must specify a fully qualified repo path"
-        fi
-        YADM_OVERRIDE_REPO="$2"
+        YADM_OVERRIDE_REPO="$(qualify_path "$2" "repo")"
         shift
       ;;
       --yadm-config) # override the standard YADM_CONFIG
-        if [[ ! "$2" =~ ^/ ]] ; then
-          error_out "You must specify a fully qualified config path"
-        fi
-        YADM_OVERRIDE_CONFIG="$2"
+        YADM_OVERRIDE_CONFIG="$(qualify_path "$2" "config")"
         shift
       ;;
       --yadm-encrypt) # override the standard YADM_ENCRYPT
-        if [[ ! "$2" =~ ^/ ]] ; then
-          error_out "You must specify a fully qualified encrypt path"
-        fi
-        YADM_OVERRIDE_ENCRYPT="$2"
+        YADM_OVERRIDE_ENCRYPT="$(qualify_path "$2" "encrypt")"
         shift
       ;;
       --yadm-archive) # override the standard YADM_ARCHIVE
-        if [[ ! "$2" =~ ^/ ]] ; then
-          error_out "You must specify a fully qualified archive path"
-        fi
-        YADM_OVERRIDE_ARCHIVE="$2"
+        YADM_OVERRIDE_ARCHIVE="$(qualify_path "$2" "archive")"
         shift
       ;;
       --yadm-bootstrap) # override the standard YADM_BOOTSTRAP
-        if [[ ! "$2" =~ ^/ ]] ; then
-          error_out "You must specify a fully qualified bootstrap path"
-        fi
-        YADM_OVERRIDE_BOOTSTRAP="$2"
+        YADM_OVERRIDE_BOOTSTRAP="$(qualify_path "$2" "bootstrap")"
         shift
       ;;
       *) # main arguments are kept intact
@@ -1550,6 +1526,20 @@ function process_global_args() {
     shift
   done
 
+}
+
+function qualify_path() {
+    local path="$1"
+    if [[ -z "$path" ]]; then
+        error_out "You can't specify an empty $2 path"
+    fi
+
+    if [[ "$path" = "." ]]; then
+        path="$PWD"
+    elif [[ "$path" != /* ]]; then
+        path="$PWD/${path#./}"
+    fi
+    echo "$path"
 }
 
 function set_yadm_dirs() {

--- a/yadm.1
+++ b/yadm.1
@@ -331,7 +331,7 @@ alias yadm='yadm --yadm-repo /alternate/path/to/repo'
 .RE
 
 The following is the full list of universal options.
-Each option should be followed by a fully qualified path.
+Each option should be followed by a path.
 .TP
 .B -Y,--yadm-dir
 Override the yadm directory.


### PR DESCRIPTION
### What does this PR do?

Add support for passing relative paths to `--yadm-*` and have them be expanded relative the current working dir as expected.

### What issues does this PR fix or reference?

None

### Previous Behavior

`yadm -Y mydir ...` didn't work.

### New Behavior

Now `yadm -Y mydir ...` is the same as `yadm -Y $(pwd)/mydir ...` which means that the shell completion for the `--yadm-*` parameters can complete dirs as normal and don't have to enforce absolute path names.

### Have [tests][1] been written for this change?

Yes

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
