### PR TITLE
Tighten up parsing of if-statement in default template

### DIFF
--- a/yadm
+++ b/yadm
@@ -413,13 +413,13 @@ function replace_vars() {
   }
 }
 function conditions() {
-  pattern = ifs blank "*("
+  pattern = ifs blank "+("
   for (label in c) {
     value = c[label]
     gsub(/[\\.^$(){}\[\]|*+?]/, "\\\\&", value)
     pattern = sprintf("%syadm\\.%s" blank "*==" blank "*\"%s\"|", pattern, label, value)
   }
-  sub(/\|$/,")",pattern)
+  sub(/\|$/, ")" blank "*%}$", pattern)
   return pattern
 }
 EOF


### PR DESCRIPTION
### What does this PR do?

Require space after if and an ending %} after the condition.

### What issues does this PR fix or reference?

None

### Previous Behavior

`{% ifyadm.class == "work"` would be an accepted if statement.

### New Behavior

Now it must be `{% if yadm.class == "work" %}`.

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
