### PR TITLE
Add 'shellcheck shell=bash' as the default

### DIFF
--- a/yadm
+++ b/yadm
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck shell=bash
 # yadm - Yet Another Dotfiles Manager
 # Copyright (C) 2015-2021 Tim Byrne
 


### PR DESCRIPTION
See https://github.com/koalaman/shellcheck/wiki/Directive#shell

### What does this PR do?

Tells shellcheck to parse yadm as a bash script by default.

### What issues does this PR fix or reference?

None.

### Previous Behavior

shellcheck parsed yadm as a 'sh' script by default, as it starts with `#!/bin/sh`

### New Behavior

No erroneous errors!

### Have [tests][1] been written for this change?

No (unneeded, as it's just a comment added)

### Have these commits been [signed with GnuPG][2]?

Yes.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
