### PR TITLE
Add OS note for Cygwin/MinGW

### DIFF
--- a/_docs/060_alternates.md
+++ b/_docs/060_alternates.md
@@ -40,6 +40,9 @@ be omitted. Most attributes can be abbreviated as a single letter.
 The OS for "Windows Subsystem for Linux" is reported as "WSL", even though uname identifies as "Linux".
 <br/>
 *
+The OS for Linux-like runtimes for Windows (e.g. MinGW, Cygwin) is obtained by running `uname -o`.
+<br/>
+*
 If `lsb_release` is not available, "distro" will be the ID specified in `/etc/os-release`.
 </sup></sub>
 


### PR DESCRIPTION
### What does this PR do?

The operating system code/name for alternate files on MinGW and Cygwin is not `WSL`, and the documentation doesn't provide a good way to figure out what yadm uses as the OS name for these. The documentation says `uname -s` is used to determine it, but digging through [the code](https://github.com/TheLocehiliosan/yadm/blob/a5b1067e02abc10c183c3411ee8b40c53e306722/yadm#L1722-L1732), it looks like it actually uses `uname -o` in these unique cases. This note makes it more clear for users of Cygwin & MinGW.

Based on the documentation, I'd think that either `WSL` or `MINGW64_NT-10.0` would be the OS name for my GitBash environment (MinGW), but it is actually `Msys`

### What issues does this PR fix or reference?

(none)

### Previous Behavior

Users have to guess what the OS name for Cygwin or MinGW environments is, or look through the code.

### New Behavior

Documentation now helps users figure out what the correct os name is for these environments.

### Have [tests][1] been written for this change?

No. Docs change only.

### Have these commits been [signed with GnuPG][2]?

No

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
