### PR TITLE
Fix typo in test (can_upgraded_... -> can_upgrade_...)

### DIFF
--- a/test/test_upgrade.py
+++ b/test/test_upgrade.py
@@ -53,8 +53,8 @@ def test_upgrade(tmpdir, runner, versions, submodule):
     if submodule:
         # When upgrading via 2.5.0 we can't have a submodule that's been added
         # after being cloned as 2.5.0 fails the upgrade in that case.
-        can_upgraded_cloned_submodule = '2.5.0' not in versions[1:]
-        if can_upgraded_cloned_submodule:
+        can_upgrade_cloned_submodule = '2.5.0' not in versions[1:]
+        if can_upgrade_cloned_submodule:
             # Check out a repo and then add it as a submodule
             run = runner(['git', '-C', str(home), 'clone', str(ext_repo), 'b'])
             assert run.success
@@ -92,7 +92,7 @@ def test_upgrade(tmpdir, runner, versions, submodule):
         run = run_version(version, 'upgrade', check_stderr=not submodule)
         if submodule:
             lines = run.err.splitlines()
-            if can_upgraded_cloned_submodule:
+            if can_upgrade_cloned_submodule:
                 assert 'Migrating git directory of' in lines[0]
                 assert str(home.join('b/.git')) in lines[1]
                 assert str(yadm_dir.join('repo.git/modules/b')) in lines[2]
@@ -108,7 +108,7 @@ def test_upgrade(tmpdir, runner, versions, submodule):
     assert run.out == 'some data'
 
     if submodule:
-        if can_upgraded_cloned_submodule:
+        if can_upgrade_cloned_submodule:
             assert home.join('b/afile').read() == 'some data'
         assert home.join('a/afile').read() == 'some data'
         assert home.join('c/afile').read() == 'some data'


### PR DESCRIPTION
### What does this PR do?

Fix my own typo in test_upgrade.py.

### What issues does this PR fix or reference?

None.

### Previous Behavior

N/A

### New Behavior

N/A

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
