### PR TITLE
Export alt values in hooks and bootstrap

### DIFF
--- a/test/test_bootstrap.py
+++ b/test/test_bootstrap.py
@@ -22,6 +22,7 @@ def test_bootstrap(
         paths.bootstrap.write(
             '#!/bin/bash\n'
             f'echo {expect}\n'
+            f'[[ $(id -un) = $YADM_USER ]] && echo "user is set"\n'
             f'exit {code}\n'
         )
         paths.bootstrap.chmod(0o775)
@@ -30,6 +31,7 @@ def test_bootstrap(
     if exists and executable:
         assert run.err == ''
         assert expect in run.out
+        assert 'user is set' in run.out
     else:
         assert expect in run.err
         assert run.out == ''

--- a/test/test_unit_score_file.py
+++ b/test/test_unit_score_file.py
@@ -6,7 +6,7 @@ CONDITION = {
         'labels': ['default'],
         'modifier': 0,
         },
-    'system': {
+    'os': {
         'labels': ['o', 'os'],
         'modifier': 1,
         },
@@ -44,9 +44,9 @@ def calculate_score(filename):
             label, value = condition.split('.', 1)
         if label in CONDITION['default']['labels']:
             score += 1000
-        elif label in CONDITION['system']['labels']:
-            if value == 'testsystem':
-                score += 1000 + CONDITION['system']['modifier']
+        elif label in CONDITION['os']['labels']:
+            if value == 'testos':
+                score += 1000 + CONDITION['os']['modifier']
             else:
                 score = 0
                 break
@@ -83,7 +83,7 @@ def calculate_score(filename):
 @pytest.mark.parametrize(
     'default', ['default', None], ids=['default', 'no-default'])
 @pytest.mark.parametrize(
-    'system', ['system', None], ids=['system', 'no-system'])
+    'system', ['os', None], ids=['os', 'no-os'])
 @pytest.mark.parametrize(
     'distro', ['distro', None], ids=['distro', 'no-distro'])
 @pytest.mark.parametrize(
@@ -97,9 +97,9 @@ def test_score_values(
     """Test score results"""
     # pylint: disable=too-many-branches
     local_class = 'testclass'
-    local_system = 'testsystem'
+    local_os = 'testos'
     local_distro = 'testdistro'
-    local_host = 'testhost'
+    local_hostname = 'testhost'
     local_user = 'testuser'
     filenames = {'filename##': 0}
 
@@ -120,7 +120,7 @@ def test_score_values(
                         newfile += ','
                     newfile += '.'.join([
                         label,
-                        local_system if match else 'badsys'
+                        local_os if match else 'bados'
                         ])
                     filenames[newfile] = calculate_score(newfile)
     if distro:
@@ -156,7 +156,7 @@ def test_score_values(
                         newfile += ','
                     newfile += '.'.join([
                         label,
-                        local_host if match else 'badhost'
+                        local_hostname if match else 'badhost'
                         ])
                     filenames[newfile] = calculate_score(newfile)
     if user:
@@ -175,11 +175,11 @@ def test_score_values(
     script = f"""
         YADM_TEST=1 source {yadm}
         score=0
-        local_class={local_class}
-        local_system={local_system}
-        local_distro={local_distro}
-        local_host={local_host}
-        local_user={local_user}
+        YADM_CLASS={local_class}
+        YADM_OS={local_os}
+        YADM_DISTRO={local_distro}
+        YADM_HOSTNAME={local_hostname}
+        YADM_USER={local_user}
     """
     expected = ''
     for filename in filenames:
@@ -207,7 +207,7 @@ def test_extensions(runner, yadm, ext):
     script = f"""
         YADM_TEST=1 source {yadm}
         score=0
-        local_user={local_user}
+        YADM_USER={local_user}
         score_file "{filename}"
         echo "$score"
     """
@@ -221,9 +221,9 @@ def test_extensions(runner, yadm, ext):
 def test_score_values_templates(runner, yadm):
     """Test score results"""
     local_class = 'testclass'
-    local_system = 'testsystem'
+    local_os = 'testos'
     local_distro = 'testdistro'
-    local_host = 'testhost'
+    local_hostname = 'testhost'
     local_user = 'testuser'
     filenames = {'filename##': 0}
 
@@ -238,11 +238,11 @@ def test_score_values_templates(runner, yadm):
     script = f"""
         YADM_TEST=1 source {yadm}
         score=0
-        local_class={local_class}
-        local_system={local_system}
-        local_distro={local_distro}
-        local_host={local_host}
-        local_user={local_user}
+        YADM_CLASS={local_class}
+        YADM_OS={local_os}
+        YADM_DISTRO={local_distro}
+        YADM_HOSTNAME={local_hostname}
+        YADM_USER={local_user}
     """
     expected = ''
     for filename in filenames:

--- a/test/test_unit_set_alt_values.py
+++ b/test/test_unit_set_alt_values.py
@@ -1,4 +1,4 @@
-"""Unit tests: set_local_alt_values"""
+"""Unit tests: set_alt_values"""
 import pytest
 import utils
 
@@ -20,18 +20,18 @@ import utils
         ]
     )
 @pytest.mark.usefixtures('ds1_copy')
-def test_set_local_alt_values(
+def test_set_alt_values(
         runner, yadm, paths, tst_sys, tst_host, tst_user, override):
     """Use issue_legacy_path_warning"""
     script = f"""
         YADM_TEST=1 source {yadm} &&
         set_operating_system &&
         YADM_DIR={paths.yadm} YADM_DATA={paths.data} configure_paths &&
-        set_local_alt_values
-        echo "class='$local_class'"
-        echo "os='$local_system'"
-        echo "host='$local_host'"
-        echo "user='$local_user'"
+        set_alt_values
+        echo "class='$YADM_CLASS'"
+        echo "os='$YADM_OS'"
+        echo "host='$YADM_HOSTNAME'"
+        echo "user='$YADM_USER'"
     """
 
     if override:
@@ -69,8 +69,8 @@ def test_distro(runner, yadm):
         YADM_TEST=1 source {yadm}
         function config() {{ echo "$1"; }}
         function query_distro() {{ echo "testdistro"; }}
-        set_local_alt_values
-        echo "distro='$local_distro'"
+        set_alt_values
+        echo "distro='$YADM_DISTRO'"
     """
     run = runner(command=['bash'], inp=script)
     assert run.success

--- a/test/test_unit_set_alt_values.py
+++ b/test/test_unit_set_alt_values.py
@@ -27,7 +27,7 @@ def test_set_alt_values(
         YADM_TEST=1 source {yadm} &&
         set_operating_system &&
         YADM_DIR={paths.yadm} YADM_DATA={paths.data} configure_paths &&
-        set_alt_values
+        ALT_VALUES_SET=0 set_alt_values
         echo "class='$YADM_CLASS'"
         echo "os='$YADM_OS'"
         echo "host='$YADM_HOSTNAME'"
@@ -69,7 +69,7 @@ def test_distro(runner, yadm):
         YADM_TEST=1 source {yadm}
         function config() {{ echo "$1"; }}
         function query_distro() {{ echo "testdistro"; }}
-        set_alt_values
+        ALT_VALUES_SET=0 set_alt_values
         echo "distro='$YADM_DISTRO'"
     """
     run = runner(command=['bash'], inp=script)

--- a/test/test_unit_template_default.py
+++ b/test/test_unit_template_default.py
@@ -5,8 +5,8 @@ FILE_MODE = 0o754
 
 # these values are also testing the handling of bizarre characters
 LOCAL_CLASS = "default_Test+@-!^Class"
-LOCAL_SYSTEM = "default_Test+@-!^System"
-LOCAL_HOST = "default_Test+@-!^Host"
+LOCAL_OS = "default_Test+@-!^System"
+LOCAL_HOSTNAME = "default_Test+@-!^Host"
 LOCAL_USER = "default_Test+@-!^User"
 LOCAL_DISTRO = "default_Test+@-!^Distro"
 TEMPLATE = f'''
@@ -36,7 +36,7 @@ wrong class 2
 {{% if yadm.os == "wrongos1" %}}
 wrong os 1
 {{% endif %}}
-{{% if yadm.os == "{LOCAL_SYSTEM}" %}}
+{{% if yadm.os == "{LOCAL_OS}" %}}
 Included section for os = {{{{yadm.os}}}} ({{{{yadm.os}}}} repeated)
 {{% endif %}}
 {{% if yadm.os == "wrongos2" %}}
@@ -45,7 +45,7 @@ wrong os 2
 {{% if yadm.hostname == "wronghost1" %}}
 wrong host 1
 {{% endif %}}
-{{% if yadm.hostname == "{LOCAL_HOST}" %}}
+{{% if yadm.hostname == "{LOCAL_HOSTNAME}" %}}
 Included section for host = {{{{yadm.hostname}}}} ({{{{yadm.hostname}}}} again)
 {{% endif %}}
 {{% if yadm.hostname == "wronghost2" %}}
@@ -74,15 +74,15 @@ end of template
 EXPECTED = f'''
 start of template
 default class  = >{LOCAL_CLASS}<
-default os     = >{LOCAL_SYSTEM}<
-default host   = >{LOCAL_HOST}<
+default os     = >{LOCAL_OS}<
+default host   = >{LOCAL_HOSTNAME}<
 default user   = >{LOCAL_USER}<
 default distro = >{LOCAL_DISTRO}<
 Included section from else
 Included section for class = {LOCAL_CLASS} ({LOCAL_CLASS} repeated)
 Multiple lines
-Included section for os = {LOCAL_SYSTEM} ({LOCAL_SYSTEM} repeated)
-Included section for host = {LOCAL_HOST} ({LOCAL_HOST} again)
+Included section for os = {LOCAL_OS} ({LOCAL_OS} repeated)
+Included section for host = {LOCAL_HOSTNAME} ({LOCAL_HOSTNAME} again)
 Included section for user = {LOCAL_USER} ({LOCAL_USER} repeated)
 Included section for distro = {LOCAL_DISTRO} ({LOCAL_DISTRO} again)
 end of template
@@ -130,11 +130,11 @@ def test_template_default(runner, yadm, tmpdir):
     script = f"""
         YADM_TEST=1 source {yadm}
         set_awk
-        local_class="{LOCAL_CLASS}"
-        local_system="{LOCAL_SYSTEM}"
-        local_host="{LOCAL_HOST}"
-        local_user="{LOCAL_USER}"
-        local_distro="{LOCAL_DISTRO}"
+        YADM_CLASS="{LOCAL_CLASS}"
+        YADM_OS="{LOCAL_OS}"
+        YADM_HOSTNAME="{LOCAL_HOSTNAME}"
+        YADM_USER="{LOCAL_USER}"
+        YADM_DISTRO="{LOCAL_DISTRO}"
         template_default "{input_file}" "{output_file}"
     """
     run = runner(command=['bash'], inp=script)
@@ -173,7 +173,7 @@ def test_include(runner, yadm, tmpdir):
     basic_file = tmpdir.join('basic')
     basic_file.write(INCLUDE_BASIC)
 
-    variables_file = tmpdir.join(f'variables.{LOCAL_SYSTEM}')
+    variables_file = tmpdir.join(f'variables.{LOCAL_OS}')
     variables_file.write(INCLUDE_VARIABLES)
 
     nested_file = tmpdir.join('dir').join('nested')
@@ -187,8 +187,8 @@ def test_include(runner, yadm, tmpdir):
     script = f"""
         YADM_TEST=1 source {yadm}
         set_awk
-        local_class="{LOCAL_CLASS}"
-        local_system="{LOCAL_SYSTEM}"
+        YADM_CLASS="{LOCAL_CLASS}"
+        YADM_OS="{LOCAL_OS}"
         template_default "{input_file}" "{output_file}"
     """
     run = runner(command=['bash'], inp=script)

--- a/test/test_unit_template_esh.py
+++ b/test/test_unit_template_esh.py
@@ -4,8 +4,8 @@ import os
 FILE_MODE = 0o754
 
 LOCAL_CLASS = "esh_Test+@-!^Class"
-LOCAL_SYSTEM = "esh_Test+@-!^System"
-LOCAL_HOST = "esh_Test+@-!^Host"
+LOCAL_OS = "esh_Test+@-!^System"
+LOCAL_HOSTNAME = "esh_Test+@-!^Host"
 LOCAL_USER = "esh_Test+@-!^User"
 LOCAL_DISTRO = "esh_Test+@-!^Distro"
 TEMPLATE = f'''
@@ -27,7 +27,7 @@ wrong class 2
 <% if [ "$YADM_OS" = "wrongos1" ]; then -%>
 wrong os 1
 <% fi -%>
-<% if [ "$YADM_OS" = "{LOCAL_SYSTEM}" ]; then -%>
+<% if [ "$YADM_OS" = "{LOCAL_OS}" ]; then -%>
 Included section for os = <%=$YADM_OS%> (<%=$YADM_OS%> repeated)
 <% fi -%>
 <% if [ "$YADM_OS" = "wrongos2" ]; then -%>
@@ -36,7 +36,7 @@ wrong os 2
 <% if [ "$YADM_HOSTNAME" = "wronghost1" ]; then -%>
 wrong host 1
 <% fi -%>
-<% if [ "$YADM_HOSTNAME" = "{LOCAL_HOST}" ]; then -%>
+<% if [ "$YADM_HOSTNAME" = "{LOCAL_HOSTNAME}" ]; then -%>
 Included section for host = <%=$YADM_HOSTNAME%> (<%=$YADM_HOSTNAME%> again)
 <% fi -%>
 <% if [ "$YADM_HOSTNAME" = "wronghost2" ]; then -%>
@@ -65,13 +65,13 @@ end of template
 EXPECTED = f'''
 start of template
 esh class  = >{LOCAL_CLASS}<
-esh os     = >{LOCAL_SYSTEM}<
-esh host   = >{LOCAL_HOST}<
+esh os     = >{LOCAL_OS}<
+esh host   = >{LOCAL_HOSTNAME}<
 esh user   = >{LOCAL_USER}<
 esh distro = >{LOCAL_DISTRO}<
 Included section for class = {LOCAL_CLASS} ({LOCAL_CLASS} repeated)
-Included section for os = {LOCAL_SYSTEM} ({LOCAL_SYSTEM} repeated)
-Included section for host = {LOCAL_HOST} ({LOCAL_HOST} again)
+Included section for os = {LOCAL_OS} ({LOCAL_OS} repeated)
+Included section for host = {LOCAL_HOSTNAME} ({LOCAL_HOSTNAME} again)
 Included section for user = {LOCAL_USER} ({LOCAL_USER} repeated)
 Included section for distro = {LOCAL_DISTRO} ({LOCAL_DISTRO} again)
 end of template
@@ -88,11 +88,11 @@ def test_template_esh(runner, yadm, tmpdir):
 
     script = f"""
         YADM_TEST=1 source {yadm}
-        local_class="{LOCAL_CLASS}"
-        local_system="{LOCAL_SYSTEM}"
-        local_host="{LOCAL_HOST}"
-        local_user="{LOCAL_USER}"
-        local_distro="{LOCAL_DISTRO}"
+        export YADM_CLASS="{LOCAL_CLASS}"
+        export YADM_OS="{LOCAL_OS}"
+        export YADM_HOSTNAME="{LOCAL_HOSTNAME}"
+        export YADM_USER="{LOCAL_USER}"
+        export YADM_DISTRO="{LOCAL_DISTRO}"
         template_esh "{input_file}" "{output_file}"
     """
     run = runner(command=['bash'], inp=script)

--- a/test/test_unit_template_j2.py
+++ b/test/test_unit_template_j2.py
@@ -5,8 +5,8 @@ import pytest
 FILE_MODE = 0o754
 
 LOCAL_CLASS = "j2_Test+@-!^Class"
-LOCAL_SYSTEM = "j2_Test+@-!^System"
-LOCAL_HOST = "j2_Test+@-!^Host"
+LOCAL_OS = "j2_Test+@-!^System"
+LOCAL_HOSTNAME = "j2_Test+@-!^Host"
 LOCAL_USER = "j2_Test+@-!^User"
 LOCAL_DISTRO = "j2_Test+@-!^Distro"
 TEMPLATE = f'''
@@ -28,7 +28,7 @@ wrong class 2
 {{%- if YADM_OS == "wrongos1" %}}
 wrong os 1
 {{%- endif %}}
-{{%- if YADM_OS == "{LOCAL_SYSTEM}" %}}
+{{%- if YADM_OS == "{LOCAL_OS}" %}}
 Included section for os = {{{{YADM_OS}}}} ({{{{YADM_OS}}}} repeated)
 {{%- endif %}}
 {{%- if YADM_OS == "wrongos2" %}}
@@ -37,7 +37,7 @@ wrong os 2
 {{%- if YADM_HOSTNAME == "wronghost1" %}}
 wrong host 1
 {{%- endif %}}
-{{%- if YADM_HOSTNAME == "{LOCAL_HOST}" %}}
+{{%- if YADM_HOSTNAME == "{LOCAL_HOSTNAME}" %}}
 Included section for host = {{{{YADM_HOSTNAME}}}} ({{{{YADM_HOSTNAME}}}} again)
 {{%- endif %}}
 {{%- if YADM_HOSTNAME == "wronghost2" %}}
@@ -66,13 +66,13 @@ end of template
 EXPECTED = f'''
 start of template
 j2 class  = >{LOCAL_CLASS}<
-j2 os     = >{LOCAL_SYSTEM}<
-j2 host   = >{LOCAL_HOST}<
+j2 os     = >{LOCAL_OS}<
+j2 host   = >{LOCAL_HOSTNAME}<
 j2 user   = >{LOCAL_USER}<
 j2 distro = >{LOCAL_DISTRO}<
 Included section for class = {LOCAL_CLASS} ({LOCAL_CLASS} repeated)
-Included section for os = {LOCAL_SYSTEM} ({LOCAL_SYSTEM} repeated)
-Included section for host = {LOCAL_HOST} ({LOCAL_HOST} again)
+Included section for os = {LOCAL_OS} ({LOCAL_OS} repeated)
+Included section for host = {LOCAL_HOSTNAME} ({LOCAL_HOSTNAME} again)
 Included section for user = {LOCAL_USER} ({LOCAL_USER} repeated)
 Included section for distro = {LOCAL_DISTRO} ({LOCAL_DISTRO} again)
 end of template
@@ -90,11 +90,11 @@ def test_template_j2(runner, yadm, tmpdir, processor):
 
     script = f"""
         YADM_TEST=1 source {yadm}
-        local_class="{LOCAL_CLASS}"
-        local_system="{LOCAL_SYSTEM}"
-        local_host="{LOCAL_HOST}"
-        local_user="{LOCAL_USER}"
-        local_distro="{LOCAL_DISTRO}"
+        export YADM_CLASS="{LOCAL_CLASS}"
+        export YADM_OS="{LOCAL_OS}"
+        export YADM_HOSTNAME="{LOCAL_HOSTNAME}"
+        export YADM_USER="{LOCAL_USER}"
+        export YADM_DISTRO="{LOCAL_DISTRO}"
         template_{processor} "{input_file}" "{output_file}"
     """
     run = runner(command=['bash'], inp=script)

--- a/yadm
+++ b/yadm
@@ -192,35 +192,35 @@ function score_file() {
       score=$((score + 0))
     # variable conditions
     elif [[ "$label" =~ ^(o|os)$ ]]; then
-      if [ "$value" = "$local_system" ]; then
+      if [ "$value" = "$YADM_OS" ]; then
         score=$((score + 1))
       else
         score=0
         return
       fi
     elif [[ "$label" =~ ^(d|distro)$ ]]; then
-      if [ "$value" = "$local_distro" ]; then
+      if [ "$value" = "$YADM_DISTRO" ]; then
         score=$((score + 2))
       else
         score=0
         return
       fi
     elif [[ "$label" =~ ^(c|class)$ ]]; then
-      if [ "$value" = "$local_class" ]; then
+      if [ "$value" = "$YADM_CLASS" ]; then
         score=$((score + 4))
       else
         score=0
         return
       fi
     elif [[ "$label" =~ ^(h|hostname)$ ]]; then
-      if [ "$value" = "$local_host" ]; then
+      if [ "$value" = "$YADM_HOSTNAME" ]; then
         score=$((score + 8))
       else
         score=0
         return
       fi
     elif [[ "$label" =~ ^(u|user)$ ]]; then
-      if [ "$value" = "$local_user" ]; then
+      if [ "$value" = "$YADM_USER" ]; then
         score=$((score + 16))
       else
         score=0
@@ -361,7 +361,7 @@ BEGIN {
   blank         = "[ 	]"
   c["class"]    = class
   c["os"]       = os
-  c["hostname"] = host
+  c["hostname"] = hostname
   c["user"]     = user
   c["distro"]   = distro
   c["source"]   = source
@@ -426,11 +426,11 @@ EOF
   )
 
   "${AWK_PROGRAM[0]}" \
-    -v class="$local_class" \
-    -v os="$local_system" \
-    -v host="$local_host" \
-    -v user="$local_user" \
-    -v distro="$local_distro" \
+    -v class="$YADM_CLASS" \
+    -v os="$YADM_OS" \
+    -v hostname="$YADM_HOSTNAME" \
+    -v user="$YADM_USER" \
+    -v distro="$YADM_DISTRO" \
     -v source="$input" \
     -v source_dir="$(dirname "$input")" \
     "$awk_pgm" \
@@ -447,12 +447,7 @@ function template_j2cli() {
   output="$2"
   temp_file="${output}.$$.$RANDOM"
 
-  YADM_CLASS="$local_class"   \
-  YADM_OS="$local_system"     \
-  YADM_HOSTNAME="$local_host" \
-  YADM_USER="$local_user"     \
-  YADM_DISTRO="$local_distro" \
-  YADM_SOURCE="$input"        \
+  YADM_SOURCE="$input" \
   "$J2CLI_PROGRAM" "$input" -o "$temp_file"
 
   if [ -f "$temp_file" ] ; then
@@ -466,12 +461,7 @@ function template_envtpl() {
   output="$2"
   temp_file="${output}.$$.$RANDOM"
 
-  YADM_CLASS="$local_class"   \
-  YADM_OS="$local_system"     \
-  YADM_HOSTNAME="$local_host" \
-  YADM_USER="$local_user"     \
-  YADM_DISTRO="$local_distro" \
-  YADM_SOURCE="$input"        \
+  YADM_SOURCE="$input" \
   "$ENVTPL_PROGRAM" --keep-template "$input" -o "$temp_file"
 
   if [ -f "$temp_file" ] ; then
@@ -485,13 +475,8 @@ function template_esh() {
   output="$2"
   temp_file="${output}.$$.$RANDOM"
 
-  "$ESH_PROGRAM" -o "$temp_file" "$input" \
-  YADM_CLASS="$local_class"   \
-  YADM_OS="$local_system"     \
-  YADM_HOSTNAME="$local_host" \
-  YADM_USER="$local_user"     \
-  YADM_DISTRO="$local_distro" \
-  YADM_SOURCE="$input"
+  YADM_SOURCE="$input" \
+  "$ESH_PROGRAM" -o "$temp_file" "$input"
 
   if [ -f "$temp_file" ] ; then
     copy_perms "$input" "$temp_file"
@@ -507,12 +492,7 @@ function alt() {
   parse_encrypt
 
   # gather values for processing alternates
-  local local_class
-  local local_system
-  local local_host
-  local local_user
-  local local_distro
-  set_local_alt_values
+  set_alt_values
 
   # only be noisy if the "alt" command was run directly
   local loud=
@@ -602,27 +582,33 @@ function remove_stale_links() {
   fi
 }
 
-function set_local_alt_values() {
+function set_alt_values() {
 
-  local_class="$(config local.class)"
+  export YADM_CLASS
+  export YADM_OS
+  export YADM_HOSTNAME
+  export YADM_USER
+  export YADM_DISTRO
 
-  local_system="$(config local.os)"
-  if [ -z "$local_system" ] ; then
-    local_system="$OPERATING_SYSTEM"
+  YADM_CLASS="$(config local.class)"
+
+  YADM_OS="$(config local.os)"
+  if [ -z "$YADM_OS" ] ; then
+    YADM_OS="$OPERATING_SYSTEM"
   fi
 
-  local_host="$(config local.hostname)"
-  if [ -z "$local_host" ] ; then
-    local_host=$(uname -n)
-    local_host=${local_host%%.*} # trim any domain from hostname
+  YADM_HOSTNAME="$(config local.hostname)"
+  if [ -z "$YADM_HOSTNAME" ] ; then
+    YADM_HOSTNAME=$(uname -n)
+    YADM_HOSTNAME=${YADM_HOSTNAME%%.*} # trim any domain from hostname
   fi
 
-  local_user="$(config local.user)"
-  if [ -z "$local_user" ] ; then
-    local_user=$(id -u -n)
+  YADM_USER="$(config local.user)"
+  if [ -z "$YADM_USER" ] ; then
+    YADM_USER=$(id -u -n)
   fi
 
-  local_distro="$(query_distro)"
+  YADM_DISTRO="$(query_distro)"
 
 }
 

--- a/yadm
+++ b/yadm
@@ -62,6 +62,7 @@ ENCRYPT_INCLUDE_FILES="unparsed"
 
 LEGACY_WARNING_ISSUED=0
 INVALID_ALT=()
+ALT_VALUES_SET="${YADM_TEST:-0}"
 
 GPG_OPTS=()
 OPENSSL_OPTS=()
@@ -584,6 +585,9 @@ function remove_stale_links() {
 
 function set_alt_values() {
 
+  [[ $ALT_VALUES_SET = 1 ]] && return
+  ALT_VALUES_SET=1
+
   export YADM_CLASS
   export YADM_OS
   export YADM_HOSTNAME
@@ -679,6 +683,8 @@ function bootstrap() {
 
   # GIT_DIR should not be set for user's bootstrap code
   unset GIT_DIR
+
+  set_alt_values
 
   echo "Executing $YADM_BOOTSTRAP"
   exec "$YADM_BOOTSTRAP"
@@ -1783,6 +1789,8 @@ function invoke_hook() {
     export -f relative_path
     export -f unix_path
     export -f mixed_path
+
+    set_alt_values
 
     "$hook_command"
     hook_status=$?

--- a/yadm.1
+++ b/yadm.1
@@ -112,7 +112,9 @@ to "false".
 .B bootstrap
 Execute
 .I $HOME/.config/yadm/bootstrap
-if it exists.
+if it exists. The variables that are set when processing Jinja or ESH templates
+(see the TEMPLATES section) are set in the environment (except for
+.IR YADM_SOURCE ).
 .TP
 .BI clone " url
 Clone a remote repository for tracking dotfiles.
@@ -891,7 +893,10 @@ will never be run. This allows one to "short-circuit" any operation using a
 .I pre_
 hook.
 
-Hooks have the following environment variables available to them at runtime:
+Hooks have the following variables, plus the variables set when processing
+Jinja or ESH templates (see the TEMPLATES section), available to them as
+environment variables at runtime (except for
+.IR YADM_SOURCE ).
 .TP
 .B YADM_HOOK_COMMAND
 The command which triggered the hook


### PR DESCRIPTION
### What does this PR do?

Rename the `local_*` variables to `YADM_*` and export them so that hooks and bootstrap can use them.

### What issues does this PR fix or reference?

* #291 

### Previous Behavior

Hooks and bootstrap had to come up with other ways to get the info.

### New Behavior

Now they can just use `YADM_*` from the environment.

### Have [tests][1] been written for this change?

Yes (a basic one)

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
