### PR TITLE
Fix updating of readonly files

### DIFF
--- a/yadm
+++ b/yadm
@@ -436,10 +436,7 @@ EOF
     "$awk_pgm" \
     "$input" > "$temp_file" || rm -f "$temp_file"
 
-  if [ -f "$temp_file" ] ; then
-    copy_perms "$input" "$temp_file"
-    mv -f "$temp_file" "$output"
-  fi
+  move_file "$input" "$output" "$temp_file"
 }
 
 function template_j2cli() {
@@ -455,10 +452,7 @@ function template_j2cli() {
   YADM_SOURCE="$input"        \
   "$J2CLI_PROGRAM" "$input" -o "$temp_file"
 
-  if [ -f "$temp_file" ] ; then
-    copy_perms "$input" "$temp_file"
-    mv -f "$temp_file" "$output"
-  fi
+  move_file "$input" "$output" "$temp_file"
 }
 
 function template_envtpl() {
@@ -474,10 +468,7 @@ function template_envtpl() {
   YADM_SOURCE="$input"        \
   "$ENVTPL_PROGRAM" --keep-template "$input" -o "$temp_file"
 
-  if [ -f "$temp_file" ] ; then
-    copy_perms "$input" "$temp_file"
-    mv -f "$temp_file" "$output"
-  fi
+  move_file "$input" "$output" "$temp_file"
 }
 
 function template_esh() {
@@ -493,9 +484,27 @@ function template_esh() {
   YADM_DISTRO="$local_distro" \
   YADM_SOURCE="$input"
 
-  if [ -f "$temp_file" ] ; then
-    copy_perms "$input" "$temp_file"
-    mv -f "$temp_file" "$output"
+  move_file "$input" "$output" "$temp_file"
+}
+
+function move_file() {
+  local input=$1
+  local output=$2
+  local temp_file=$3
+
+  if [ ! -f "$temp_file" ] ; then
+    return 0
+  fi
+
+  local read_only
+  copy_perms "$input" "$temp_file"
+  if [[ -e "$output" && ! -w "$output" ]]; then
+    read_only=1
+    chmod u+w "$output"
+  fi
+  mv -f "$temp_file" "$output"
+  if [ -n "$read_only" ]; then
+    chmod u-w "$output"
   fi
 }
 


### PR DESCRIPTION
### What does this PR do?

Allows `yadm alt` to update files that are read-only (mode 400 / -r--------).

### What issues does this PR fix or reference?

None.

### Previous Behavior

[google-authenticator](https://github.com/google/google-authenticator-libpam) stores its configuration in `~/.google_authenticator`. Each time the user logs in, the file is set to mode 400, even if the file is 600. `yadm alt` would then fail to move the `$temp_file` to the `$output` file, as the `$output` file was read-only.

### New Behavior

`yadm alt` can successfully update read-only files.

### Have [tests][1] been written for this change?

No, but all current tests pass.

### Have these commits been [signed with GnuPG][2]?

Yes.

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
