### PR TITLE
Change FAQ to reference "encrypt" instead of "files.gpg".

### DIFF
--- a/_docs/110_faq.md
+++ b/_docs/110_faq.md
@@ -113,18 +113,18 @@ you when you clone your repository.
 ### Should I `yadm add` encrypted files to repository?
 
 No, you should not. Files you want encrypted should be added to the file
-`.config/yadm/files.gpg` using the `yadm encrypt` command. Then
-`.config/yadm/files.gpg` should be added to the yadm repository. This way, only
+`.config/yadm/encrypt` using the `yadm encrypt` command. Then
+`.config/yadm/encrypt` should be added to the yadm repository. This way, only
 an encrypted collection of those files are put into the repository. After
 cloning or updating your repository, you can use `yadm decrypt` to extract those
-files from `.config/yadm/files.gpg`. See the
+files from `.config/yadm/encrypt`. See the
 [encryption help](encryption) for more details.
 
 ### I modified an encrypted file, but yadm doesn't show any modifications. Why?
 
 If you changed files which are matched by `.config/yadm/encrypt`, you must
-re-run `yadm encrypt` to generate a new version of `.config/yadm/files.gpg`.
-Then `.config/yadm/files.gpg` can be added to a new commit.
+re-run `yadm encrypt` to generate a new version of `.config/yadm/encrypt`.
+Then `.config/yadm/encrypt` can be added to a new commit.
 
 ### Why do I get the error `Inappropriate ioctl for device` when encrypting.
 


### PR DESCRIPTION
Fixes issue #334.
