### PR TITLE
fix: Find symlinks in bootstrap-in-dir

### DIFF
--- a/contrib/bootstrap/bootstrap-in-dir
+++ b/contrib/bootstrap/bootstrap-in-dir
@@ -14,7 +14,7 @@ if [[ ! -d "$BOOTSTRAP_D" ]]; then
     exit 1
 fi
 
-find "$BOOTSTRAP_D" -type f | sort | while IFS= read -r bootstrap; do
+find -L "$BOOTSTRAP_D" -type f | sort | while IFS= read -r bootstrap; do
     if [[ -x "$bootstrap" && ! "$bootstrap" =~ "##" && ! "$bootstrap" =~ "~$" ]]; then
         if ! "$bootstrap"; then
             echo "Error: bootstrap '$bootstrap' failed" >&2


### PR DESCRIPTION
Fixes #339

### What does this PR do?

Supporting finding files that are symlinks to files

### What issues does this PR fix or reference?

#339 

### Previous Behavior

find skipped files that were pointed to by symlinks

### New Behavior

find find files that were pointed to by symlinks

### Have [tests][1] been written for this change?

No (it's in the contrib folder)

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
