### PR TITLE
feat: Add support for env vars in templates

### DIFF
--- a/test/test_unit_template_default.py
+++ b/test/test_unit_template_default.py
@@ -202,3 +202,22 @@ def test_include(runner, yadm, tmpdir):
     assert run.err == ''
     assert output_file.read() == EXPECTED_INCLUDE
     assert os.stat(output_file).st_mode == os.stat(input_file).st_mode
+
+
+def test_env(runner, yadm, tmpdir):
+    """Test env"""
+
+    input_file = tmpdir.join('input')
+    input_file.write('{{env.PWD}}', ensure=True)
+    input_file.chmod(FILE_MODE)
+    output_file = tmpdir.join('output')
+
+    script = f"""
+        YADM_TEST=1 source {yadm}
+        set_awk
+        template_default "{input_file}" "{output_file}"
+    """
+    run = runner(command=['bash'], inp=script)
+    assert run.success
+    assert run.err == ''
+    assert output_file.read() == os.environ['PWD']

--- a/test/test_unit_template_default.py
+++ b/test/test_unit_template_default.py
@@ -220,4 +220,4 @@ def test_env(runner, yadm, tmpdir):
     run = runner(command=['bash'], inp=script)
     assert run.success
     assert run.err == ''
-    assert output_file.read() == os.environ['PWD']
+    assert output_file.read().strip() == os.environ['PWD']

--- a/yadm
+++ b/yadm
@@ -409,6 +409,9 @@ function replace_vars() {
   for (label in c) {
     gsub(("{{" blank "*yadm\\." label blank "*}}"), c[label])
   }
+  for (label in ENVIRON) {
+    gsub(("{{" blank "*env\\." label blank "*}}"), ENVIRON[label])
+  }
 }
 function conditions() {
   pattern = ifs blank "+("


### PR DESCRIPTION
### What does this PR do?

Allows `{{ env.HOME }}` in templates.

### What issues does this PR fix or reference?

This allows us to replace
```
{% if yadm.os == "Darwin" %}
home="/Users/{{ yadm.user }}"
{% else %}
home="/home/{{ yadm.user }}"
{% endif %}
```
with
```
home="{{ env.HOME }}"
```

### Previous Behavior

See above.

### New Behavior

See above.

### Have [tests][1] been written for this change?

No. Sorry, I'm not skilled in writing tests in python.

### Have these commits been [signed with GnuPG][2]?

Yes.

---

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
