### PR TITLE
fix “Mackbook” typo in manpage

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+3.1.1
+  * Fix clone support for older versions of Git (#348)
+  * Fix support for multiple GPG recipients (#342)
+  * Find symlinks in bootstrap-in-dir (#340)
+
 3.1.0
   * Use `git clone` directly during clone (#289, #323)
   * Fix compatibility bug with Git completions (#318, #321)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The star count helps others discover yadm.
 [master-badge]: https://img.shields.io/github/workflow/status/TheLocehiliosan/yadm/Tests/master?label=master
 [master-commits]: https://github.com/TheLocehiliosan/yadm/commits/master
 [master-date]: https://img.shields.io/github/last-commit/TheLocehiliosan/yadm/master.svg?label=master
-[obs-badge]: https://img.shields.io/badge/OBS-v3.1.0-blue
+[obs-badge]: https://img.shields.io/badge/OBS-v3.1.1-blue
 [obs-link]: https://software.opensuse.org//download.html?project=home%3ATheLocehiliosan%3Ayadm&package=yadm
 [releases-badge]: https://img.shields.io/github/tag/TheLocehiliosan/yadm.svg?label=latest+release
 [releases-link]: https://github.com/TheLocehiliosan/yadm/releases

--- a/yadm
+++ b/yadm
@@ -21,7 +21,7 @@ if [ -z "$BASH_VERSION" ]; then
   [ "$YADM_TEST" != 1 ] && exec bash "$0" "$@"
 fi
 
-VERSION=3.1.0
+VERSION=3.1.1
 
 YADM_WORK="$HOME"
 YADM_DIR=

--- a/yadm.1
+++ b/yadm.1
@@ -1,5 +1,5 @@
 .\" vim: set spell so=8:
-.TH yadm 1 "3 April 2021" "3.1.0"
+.TH yadm 1 "23 August 2021" "3.1.1"
 
 .SH NAME
 

--- a/yadm.md
+++ b/yadm.md
@@ -450,7 +450,7 @@
        $HOME/path/example.txt    ->    $HOME/path/example.txt##os.Darwin,host-
        name.host2
 
-       However, on another Mackbook named "host3", yadm will create a symbolic
+       However, on another Macbook named "host3", yadm will create a symbolic
        link which looks like this:
 
        $HOME/path/example.txt -> $HOME/path/example.txt##os.Darwin

--- a/yadm.spec
+++ b/yadm.spec
@@ -1,7 +1,7 @@
 %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
 Name: yadm
 Summary: Yet Another Dotfiles Manager
-Version: 3.1.0
+Version: 3.1.1
 Group: Development/Tools
 Release: 1%{?dist}
 URL: https://yadm.io


### PR DESCRIPTION
`s/Mackbook/Macbook/`