### PR TITLE
Allow interaction in bootstrap scripts

### DIFF
--- a/contrib/bootstrap/bootstrap-in-dir
+++ b/contrib/bootstrap/bootstrap-in-dir
@@ -14,11 +14,12 @@ if [[ ! -d "$BOOTSTRAP_D" ]]; then
     exit 1
 fi
 
-find -L "$BOOTSTRAP_D" -type f | sort | while IFS= read -r bootstrap; do
+# Allow interaction in bootstrap scripts
+while IFS= read -r bootstrap <&3 ; do
     if [[ -x "$bootstrap" && ! "$bootstrap" =~ "##" && ! "$bootstrap" =~ "~$" ]]; then
         if ! "$bootstrap"; then
             echo "Error: bootstrap '$bootstrap' failed" >&2
             exit 1
         fi
     fi
-done
+done 3< <(find -L "$BOOTSTRAP_D" -type f | sort)


### PR DESCRIPTION
This fix enhances the bootstrap process by allowing interaction in scripts. If the bootstrap script has a `read...` command, it now works just fine.

### What does this PR do?

[A clear and concise description of what this pull request accomplishes.]

### What issues does this PR fix or reference?

<!--
Be sure to preface the issue/PR numbers with a "#".
-->
[A list of related issues / pull requests.]

### Previous Behavior

[Describe the existing behavior.]

### New Behavior

[Describe the behavior, after this PR is applied.]

### Have [tests][1] been written for this change?

[Yes / No]

### Have these commits been [signed with GnuPG][2]?

[Yes / No]

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
