### PR TITLE
Fix Makefile portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,9 +192,9 @@ install:
 	@[ -n "$(PREFIX)" ] || { echo "PREFIX is not set"; exit 1; }
 	@{\
 		set -e                                               ;\
-		bin="$(PREFIX)/bin"                                  ;\
-		doc="$(PREFIX)/share/doc/yadm"                       ;\
-		man="$(PREFIX)/share/man/man1"                       ;\
+		bin="$(DESTDIR)$(PREFIX)/bin"                        ;\
+		doc="$(DESTDIR)$(PREFIX)/share/doc/yadm"             ;\
+		man="$(DESTDIR)$(PREFIX)/share/man/man1"             ;\
 		install -d "$$bin" "$$doc" "$$man"                   ;\
 		install -m 0755 yadm "$$bin"                         ;\
 		install -m 0644 yadm.1 "$$man"                       ;\


### PR DESCRIPTION
### What does this PR do?

Permits a portable install without breaking `$(PREFIX)` (and the software altogether)

### Previous Behavior

With the old version, that wasn't possible, as it would try to install the software in the worker folder, of course something denied on public instances (like OBS).

### New Behavior

Adding `$(DESTDIR)` before all paths ensure that you can install to another folder, old behaviour is restored if the variable is not declared as it is assumed empty by make

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
