### PR TITLE
Support overriding architecture

### DIFF
--- a/test/test_unit_set_local_alt_values.py
+++ b/test/test_unit_set_local_alt_values.py
@@ -7,6 +7,7 @@ import utils
     'override', [
         False,
         'class',
+        'arch',
         'os',
         'hostname',
         'user',
@@ -14,6 +15,7 @@ import utils
     ids=[
         'no-override',
         'override-class',
+        'override-arch',
         'override-os',
         'override-hostname',
         'override-user',
@@ -21,7 +23,7 @@ import utils
     )
 @pytest.mark.usefixtures('ds1_copy')
 def test_set_local_alt_values(
-        runner, yadm, paths, tst_sys, tst_host, tst_user, override):
+        runner, yadm, paths, tst_arch, tst_sys, tst_host, tst_user, override):
     """Use issue_legacy_path_warning"""
     script = f"""
         YADM_TEST=1 source {yadm} &&
@@ -29,6 +31,7 @@ def test_set_local_alt_values(
         YADM_DIR={paths.yadm} YADM_DATA={paths.data} configure_paths &&
         set_local_alt_values
         echo "class='$local_class'"
+        echo "arch='$local_arch'"
         echo "os='$local_system'"
         echo "host='$local_host'"
         echo "user='$local_user'"
@@ -45,6 +48,11 @@ def test_set_local_alt_values(
         assert "class='override'" in run.out
     else:
         assert "class=''" in run.out
+
+    if override == 'arch':
+        assert "arch='override'" in run.out
+    else:
+        assert f"arch='{tst_arch}'" in run.out
 
     if override == 'os':
         assert "os='override'" in run.out

--- a/yadm
+++ b/yadm
@@ -837,7 +837,7 @@ EOF
 function config() {
 
   use_repo_config=0
-  local_options="^local\.(class|os|hostname|user)$"
+  local_options="^local\.(class|arch|os|hostname|user)$"
   for option in "$@"; do
     [[ "$option" =~ $local_options ]] && use_repo_config=1
   done

--- a/yadm.1
+++ b/yadm.1
@@ -427,7 +427,7 @@ Disable the permission changes to
 This feature is enabled by default.
 
 .RE
-The following four "local" configurations are not stored in the
+The following five "local" configurations are not stored in the
 .IR $HOME/.config/yadm/config,
 they are stored in the local repository.
 
@@ -435,6 +435,9 @@ they are stored in the local repository.
 .B local.class
 Specify a class for the purpose of symlinking alternate files.
 By default, no class will be matched.
+.TP
+.B local.arch
+Override the architecture for the purpose of symlinking alternate files.
 .TP
 .B local.hostname
 Override the hostname for the purpose of symlinking alternate files.
@@ -601,8 +604,9 @@ command. The following sets the class to be "Work".
 
   yadm config local.class Work
 
-Similarly, the values of os, hostname, and user can be manually overridden
-using the configuration options
+Similarly, the values of architecture, os, hostname, and user can be manually
+overridden using the configuration options
+.BR local.arch ,
 .BR local.os ,
 .BR local.hostname ,
 and


### PR DESCRIPTION
### What does this PR do?

Allow override of architecture in the same way as os, hostname and user.

### What issues does this PR fix or reference?

#203 

### Previous Behavior

local.arch wasn't stored in the local config

### New Behavior

Now it is.

### Have [tests][1] been written for this change?

Yes

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
