### PR TITLE
Bump esh to version 0.3.1 in docker image

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Tim Byrne <sultan@locehilios.com>
 
 # Shellcheck and esh versions
 ARG SC_VER=0.7.1
-ARG ESH_VER=0.3.0
+ARG ESH_VER=0.3.1
 
 # Install prerequisites and configure UTF-8 locale
 RUN \


### PR DESCRIPTION
### What does this PR do?

Use latest esh in test image.

### What issues does this PR fix or reference?

N/A

### Previous Behavior

Was using esh 0.3.0.

### New Behavior

Now using esh 0.3.1.

### Have [tests][1] been written for this change?

No, but the existing tests have been tested with the new version and they pass.

### Have these commits been [signed with GnuPG][2]?

Yes.

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
