### PR TITLE
Bump shellcheck to version 0.8.0 in docker image

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 MAINTAINER Tim Byrne <sultan@locehilios.com>
 
 # Shellcheck and esh versions
-ARG SC_VER=0.7.1
+ARG SC_VER=0.8.0
 ARG ESH_VER=0.3.0
 
 # Install prerequisites and configure UTF-8 locale

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -25,7 +25,7 @@ def pytest_addoption(parser):
 @pytest.fixture(scope='session')
 def shellcheck_version():
     """Version of shellcheck supported"""
-    return '0.7.1'
+    return '0.8.0'
 
 
 @pytest.fixture(scope='session')

--- a/yadm
+++ b/yadm
@@ -170,8 +170,8 @@ function score_file() {
   tgt="${src%%##*}"
   conditions="${src#*##}"
 
-  if [ "${tgt#$YADM_ALT/}" != "${tgt}" ]; then
-    tgt="${YADM_BASE}/${tgt#$YADM_ALT/}"
+  if [ "${tgt#"$YADM_ALT/"}" != "${tgt}" ]; then
+    tgt="${YADM_BASE}/${tgt#"$YADM_ALT/"}"
   fi
 
   score=0
@@ -552,8 +552,8 @@ function alt() {
     if [[ $possible_alt =~ .\#\#. ]]; then
       base_alt="${possible_alt%%##*}"
       yadm_alt="${YADM_BASE}/${base_alt}"
-      if [ "${yadm_alt#$YADM_ALT/}" != "${yadm_alt}" ]; then
-        base_alt="${yadm_alt#$YADM_ALT/}"
+      if [ "${yadm_alt#"$YADM_ALT/"}" != "${yadm_alt}" ]; then
+        base_alt="${yadm_alt#"$YADM_ALT/"}"
       fi
       possible_alts+=("$YADM_BASE/${base_alt}")
     fi
@@ -1382,7 +1382,7 @@ function upgrade() {
   ;
   do
     if [ -e "$legacy_path" ]; then
-      new_filename=${legacy_path#$YADM_LEGACY_DIR/}
+      new_filename="${legacy_path#"$YADM_LEGACY_DIR/"}"
       new_filename="$YADM_DIR/$new_filename"
       actions_performed=1
       echo "Moving $legacy_path to $new_filename"
@@ -1946,7 +1946,7 @@ function relative_path() {
   result=""
 
   count=0
-  while [ "${full#$common_part}" == "${full}" ]; do
+  while [ "${full#"$common_part"}" == "${full}" ]; do
       [ "$count" = "500" ] && return # this is a failsafe
       # no match, means that candidate common part is not correct
       # go up one level (reduce common part)
@@ -1967,7 +1967,7 @@ function relative_path() {
 
   # since we now have identified the common part,
   # compute the non-common part
-  forward_part="${full#$common_part}"
+  forward_part="${full#"$common_part"}"
 
   # and now stick all parts together
   if [[ -n $result ]] && [[ -n $forward_part ]]; then


### PR DESCRIPTION
### What does this PR do?

Update shellcheck to latest version and fix one new warning: [SC2295](https://github.com/koalaman/shellcheck/wiki/SC2295).

### What issues does this PR fix or reference?

None.

### Previous Behavior

Was using version 0.7.1.

### New Behavior

Now using version 0.8.0.

### Have [tests][1] been written for this change?

No, but the existing one has been updated.

### Have these commits been [signed with GnuPG][2]?

Yes.

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
