### PR TITLE
Mention yadm in official arch repos

### DIFF
--- a/_docs/020_install.md
+++ b/_docs/020_install.md
@@ -26,10 +26,10 @@ A version of yadm is available via standard package repositories. Use `apt-get` 
 
 ## Arch Linux
 
-yadm is available in the [Arch User Repos](https://wiki.archlinux.org/index.php/Arch_User_Repository) and can be installed with an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers) or with [Makepkg](https://wiki.archlinux.org/index.php/Makepkg).
+yadm is available in the official repository, simply use `pacman` to install it.
 
 ```
-yay -Syu yadm-git
+sudo pacman -S yadm
 ```
 
 ## Gentoo Linux


### PR DESCRIPTION
### What does this PR do?

yadm now exists in the official `community` repo. This PR changes the install command to reflect it.

### What issues does this PR fix or reference?

Fixes #401 

### Previous Behavior

Asking the user to use an AUR helper

### New Behavior

Asking the user to use the official package manager

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes
