### PR TITLE
[Docs] Add openSUSE install instructions

### DIFF
--- a/_docs/020_install.md
+++ b/_docs/020_install.md
@@ -15,10 +15,30 @@ brew install yadm
 
 ## RPM Based Installations
 
-For RPM based systems like Fedora, Red Hat, CentOS, openSUSE, etc, there are
-repositories hosted by openSUSE Build Service.
+For RPM based systems like Fedora, Red Hat, CentOS, etc, there are repositories hosted by openSUSE Build Service.
 
 Follow this link for [repositories and installation instructions][OBS].
+
+## openSUSE
+
+### Tumbleweed
+
+`yadm` is available in the official repository.
+Use `zypper` or `dnf` to install.
+
+### Leap/SLE 15
+
+`yadm` is available to install manually via the `utilities` repository
+
+Instructions are to be found in [OBS](https://software.opensuse.org//download.html?project=utilities&package=yadm)
+
+*Note : 15.3 and further are located under SLE and not openSUSE*
+
+It is recommended to modify the priority of the repository to limit breakage :
+
+```
+zypper modifyrepo -p 100 utilities
+```
 
 ## Ubuntu/Debian
 


### PR DESCRIPTION
### What does this PR do?

openSUSE has accepted `yadm` as an official package, add the respective install instructions

### Previous Behavior

Asked the use to use a third-party (from a distro standpoint) repo

### New Behavior

Asks the user to use the official package manager

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
