### PR TITLE
Fix zsh hanging when tab completing add/checkout

### DIFF
--- a/completion/zsh/_yadm
+++ b/completion/zsh/_yadm
@@ -8,12 +8,13 @@ zstyle -T ':completion:*:yadm:*:yadm' group-name && \
     zstyle ':completion:*:yadm:*:yadm' group-name ''
 
 function _yadm-add(){
+  local -a yadm_options yadm_path
   yadm_path="$(yadm rev-parse --show-toplevel)"
-  yadm_options=$(yadm status --porcelain=v1 |
-    awk -v yadm_path=${yadm_path} '{printf "%s/\"%s\"\\:\"%s\" ",  yadm_path, $2, $1 }' )
-  _alternative \
-    "args:custom arg:(($yadm_options))" \
-    'files:filename:_files'
+  yadm_options=($(yadm status --porcelain=v1 |
+    awk -v yadm_path=${yadm_path} '{printf "%s/%s ",  yadm_path, $2}' ))
+
+  _describe 'command' yadm_options
+  _files
 }
 
 function _yadm-checkout(){ 

--- a/completion/zsh/_yadm
+++ b/completion/zsh/_yadm
@@ -12,10 +12,8 @@ function _yadm-add(){
   yadm_path="$(yadm rev-parse --show-toplevel)"
   yadm_options=($(yadm status --porcelain=v1 |
     awk -v yadm_path=${yadm_path} '{printf "%s/%s:%s\n",  yadm_path, $2, $1}' ))
-  local expl
-  local line=( $yadm_options[1,CURRENT-1] )
 
-  _describe 'command' yadm_options -F line
+  _describe 'command' yadm_options
   _files
 }
 

--- a/completion/zsh/_yadm
+++ b/completion/zsh/_yadm
@@ -7,6 +7,19 @@ zstyle -T ':completion:*:yadm:argument-1:descriptions:' format && \
 zstyle -T ':completion:*:yadm:*:yadm' group-name && \
     zstyle ':completion:*:yadm:*:yadm' group-name ''
 
+function _yadm-add(){
+  yadm_path="$(yadm rev-parse --show-toplevel)"
+  yadm_options=$(yadm status --porcelain=v1 |
+    awk -v yadm_path=${yadm_path} '{printf "%s/\"%s\"\\:\"%s\" ",  yadm_path, $2, $1 }' )
+  _alternative \
+    "args:custom arg:(($yadm_options))" \
+    'files:filename:_files'
+}
+
+function _yadm-checkout(){ 
+    _yadm-add 
+}
+
 _yadm-alt() {
     return 0
 }

--- a/completion/zsh/_yadm
+++ b/completion/zsh/_yadm
@@ -11,9 +11,11 @@ function _yadm-add(){
   local -a yadm_options yadm_path
   yadm_path="$(yadm rev-parse --show-toplevel)"
   yadm_options=($(yadm status --porcelain=v1 |
-    awk -v yadm_path=${yadm_path} '{printf "%s/%s ",  yadm_path, $2}' ))
+    awk -v yadm_path=${yadm_path} '{printf "%s/%s:%s\n",  yadm_path, $2, $1}' ))
+  local expl
+  local line=( $yadm_options[1,CURRENT-1] )
 
-  _describe 'command' yadm_options
+  _describe 'command' yadm_options -F line
   _files
 }
 


### PR DESCRIPTION
### What does this PR do?

Replaces built in `git add` completion that hangs on the `${HOME}` with a combination `yadm status`  `ls` completion that should be good enough for users to:
- add changed files
- add a new file they want to track in source control.

### What issues does this PR fix or reference?

#359

[A list of related issues / pull requests.]

### Previous Behavior

Typing `yadm add <TAB>` would hang in the zsh terminal as it tries to `git-add_complete` thousands of files

### New Behavior

`yadm add <TAB> is now a resolvable completion`


https://user-images.githubusercontent.com/36175703/167266174-12a91eb2-4791-4206-9fd3-5a2ce6cca8ee.mp4


### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
