### PR TITLE
[Makefile] Support docker-like OCI engines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -212,6 +212,11 @@ these principles when making changes.
     ```text
     $ make test
     ```
+    If you don't use `docker` but an OCI engine akin to `podman`, you can set it through the `OCI` switch for every target
+    
+    ```text
+    $ make test OCI=podman
+    ```
 
 5. Create a feature branch, based off the `develop` branch.
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PYTESTS = $(wildcard test/test_*.py)
-IMAGE = yadm/testbed:2022-01-07
+IMAGE = docker.io/yadm/testbed:2022-01-07
+OCI = docker
 
 .PHONY: all
 all:
@@ -94,7 +95,7 @@ test:
 		py.test -v $(testargs); \
 	else \
 		$(MAKE) -s require-docker && \
-		docker run \
+		$(OCI) run \
 			--rm -t$(shell test -t 0 && echo i) \
 			-v "$(CURDIR):/yadm:ro" \
 			$(IMAGE) \
@@ -117,7 +118,7 @@ test:
 .PHONY: testhost
 testhost: require-docker .testyadm
 	@echo "Starting testhost"
-	@docker run \
+	@$(OCI) run \
 		-w /root \
 		--hostname testhost \
 		--rm -it \
@@ -129,7 +130,7 @@ testhost: require-docker .testyadm
 scripthost: require-docker .testyadm
 	@echo "Starting scripthost \(recording script\)"
 	@printf '' > script.gz
-	@docker run \
+	@$(OCI) run \
 		-w /root \
 		--hostname scripthost \
 		--rm -it \
@@ -159,7 +160,7 @@ testenv:
 
 .PHONY: image
 image:
-	@docker build -f test/Dockerfile . -t "$(IMAGE)"
+	@$(OCI) build -f test/Dockerfile . -t "$(IMAGE)"
 
 
 .PHONY: man
@@ -204,11 +205,11 @@ install:
 
 .PHONY: sync-clock
 sync-clock:
-	docker run --rm --privileged alpine hwclock -s
+	$(OCI) run --rm --privileged alpine hwclock -s
 
 .PHONY: require-docker
 require-docker:
-	@if ! command -v "docker" > /dev/null 2>&1; then \
-		echo "Sorry, this make target requires docker to be installed."; \
+	@if ! command -v $(OCI) > /dev/null 2>&1; then \
+		echo "Sorry, this make target requires docker to be installed, to use another docker-compatible engine, like podman, re-run the make command adding OCI=podman"; \
 		false; \
 	fi


### PR DESCRIPTION
### What does this PR do?

Remove the hard-coding for docker and allow other OCI engines to be used for testing, but keeping a hard-coded default of `docker`

### Previous Behavior

Short of installing docker or symlinking `podman` (for ex.) to `docker`, you can't use something like [podman](https://podman.io).

### New Behavior

- Create OCI variable to override the docker engine
- Refactor the test-docker error message to expose this possibility

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
