### PR TITLE
[Alternates] Support `_` as space replacement when scoring alternates

### DIFF
--- a/yadm
+++ b/yadm
@@ -204,14 +204,14 @@ function score_file() {
         return
       fi
     elif [[ "$label" =~ ^(d|distro)$ ]]; then
-      if [ "$value" = "$local_distro" ]; then
+      if [ "${value/\ /_}" = "${local_distro/\ /_}" ]; then
         score=$((score + 4))
       else
         score=0
         return
       fi
     elif [[ "$label" =~ ^(f|distro_family)$ ]]; then
-      if [ "$value" = "$local_distro_family" ]; then
+      if [ "${value/\ /_}" = "${local_distro_family/\ /_}" ]; then
         score=$((score + 8))
       else
         score=0


### PR DESCRIPTION
### What does this PR do?

Replace all spaces by `_` at scoring-time (only for `distro`/`distro-family` since it is the only values that can conceivably have a space in them)  to allow for `_` to be used as space replacement when naming alternates

### What issues does this PR fix or reference?

#421 

### Previous Behavior

It would have required a ` ` to have a correct alternate scoring, which messes with some completion engines (e.g. in `zsh`) and makes the filename more complicated to parse when using other tools

### New Behavior

It can take `_` as a space replacement

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
