### PR TITLE
Add detection for Android

### DIFF
--- a/yadm
+++ b/yadm
@@ -684,7 +684,7 @@ function set_local_alt_values() {
   local_distro_family="$(query_distro_family)"
 
 }
-
+u
 function alt_linking() {
 
   local alt_scores=()
@@ -1772,7 +1772,9 @@ function set_operating_system() {
       OPERATING_SYSTEM=$(uname -o)
       ;;
     *)
-      ;;
+      if [[ "$(uname -o)" == "Android" ]]; then
+        OPERATING_SYSTEM=Android
+      fi
   esac
 
 }


### PR DESCRIPTION
Android is a subtype of Linux (according to `uname -s`), but let's be honest, an Android doesn't behave like a typical Linux distribution.

### What does this PR do?

Add detection for Android platform as OS.

### Previous Behavior

Android platform is detected as Linux

### New Behavior

Android is now Android.

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes.

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
