### PR TITLE
Fix typo in `brew` bootstrap docs

### DIFF
--- a/_docs/050_bootstrap.md
+++ b/_docs/050_bootstrap.md
@@ -63,7 +63,7 @@ if [ "$system_type" = "Darwin" ]; then
   # install homebrew if it's missing
   if ! command -v brew >/dev/null 2>&1; then
     echo "Installing homebrew"
-    /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
   fi
 
   if [ -f "$HOME/.Brewfile" ]; then


### PR DESCRIPTION
### What does this PR do?

Fix a typo

### What issues does this PR fix or reference?

N/A

### Previous Behavior

N/A

### New Behavior

`HomeBrew` bootstrapping example will now work

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
