### PR TITLE
Update encryption info in FAQ and use all paths relative to ~/ for clarity

### DIFF
--- a/_docs/110_faq.md
+++ b/_docs/110_faq.md
@@ -113,18 +113,18 @@ you when you clone your repository.
 ### Should I `yadm add` encrypted files to repository?
 
 No, you should not. Files you want encrypted should be added to the file
-`.config/yadm/files.gpg` using the `yadm encrypt` command. Then
-`.config/yadm/files.gpg` should be added to the yadm repository. This way, only
+`$HOME/.local/share/yadm/archive` using the `yadm encrypt` command. Then
+`$HOME/.local/share/yadm/archive` should be added to the yadm repository. This way, only
 an encrypted collection of those files are put into the repository. After
 cloning or updating your repository, you can use `yadm decrypt` to extract those
-files from `.config/yadm/files.gpg`. See the
+files from `$HOME/.local/share/yadm/archive`. See the
 [encryption help](encryption) for more details.
 
 ### I modified an encrypted file, but yadm doesn't show any modifications. Why?
 
 If you changed files which are matched by `.config/yadm/encrypt`, you must
-re-run `yadm encrypt` to generate a new version of `.config/yadm/files.gpg`.
-Then `.config/yadm/files.gpg` can be added to a new commit.
+re-run `yadm encrypt` to generate a new version of `$HOME/.local/share/yadm/archive`.
+Then `$HOME/.local/share/yadm/archive` can be added to a new commit.
 
 ### Why do I get the error `Inappropriate ioctl for device` when encrypting.
 

--- a/_docs/110_faq.md
+++ b/_docs/110_faq.md
@@ -105,7 +105,7 @@ Of course. You only need `gpg` installed if you plan on using the
 encrypt/decrypt features. yadm will tell you if it is missing a dependency
 for any command.
 
-### Should I `yadm add` my `.config/yadm/encrypt` file?
+### Should I `yadm add` my `~/.config/yadm/encrypt` file?
 
 Yes! This way your configuration for what files should be encrypted will follow
 you when you clone your repository.
@@ -113,18 +113,18 @@ you when you clone your repository.
 ### Should I `yadm add` encrypted files to repository?
 
 No, you should not. Files you want encrypted should be added to the file
-`$HOME/.local/share/yadm/archive` using the `yadm encrypt` command. Then
-`$HOME/.local/share/yadm/archive` should be added to the yadm repository. This way, only
+`~/.local/share/yadm/archive` using the `yadm encrypt` command. Then
+`~/.local/share/yadm/archive` should be added to the yadm repository. This way, only
 an encrypted collection of those files are put into the repository. After
 cloning or updating your repository, you can use `yadm decrypt` to extract those
-files from `$HOME/.local/share/yadm/archive`. See the
+files from `~/.local/share/yadm/archive`. See the
 [encryption help](encryption) for more details.
 
 ### I modified an encrypted file, but yadm doesn't show any modifications. Why?
 
-If you changed files which are matched by `.config/yadm/encrypt`, you must
-re-run `yadm encrypt` to generate a new version of `$HOME/.local/share/yadm/archive`.
-Then `$HOME/.local/share/yadm/archive` can be added to a new commit.
+If you changed files which are matched by `~/.config/yadm/encrypt`, you must
+re-run `yadm encrypt` to generate a new version of `~/.local/share/yadm/archive`.
+Then `~/.local/share/yadm/archive` can be added to a new commit.
 
 ### Why do I get the error `Inappropriate ioctl for device` when encrypting.
 
@@ -175,7 +175,7 @@ Git. Be sure to add these `.gitignore` files to your repo, so they can be synced
 along with your other configurations.
 
 Another option is to add patterns to
-`$HOME/.local/share/yadm/repo.git/info/exclude`.
+`~/.local/share/yadm/repo.git/info/exclude`.
 If you use this file, be sure to add your patterns above any
 `yadm-auto-excludes` line, as all lines below this can be overwritten by yadm
 when encrypting data.


### PR DESCRIPTION
### What does this PR do?

Current FAQ has deprecated info about the location of the encrypted file:

```
.config/yadm/files.gpg -> ~/.local/share/yadm/archive
```

Also, for clarity, probably it is a good idea to use all paths relative to $HOME or ~/.

### What issues does this PR fix or reference?

N/A

### Previous Behavior

FAQ uses `.config/yadm/files.gpg`

### New Behavior

FAQ uses `~/.local/share/yadm/archive`, and all full paths start with `~/`.

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
