### PR TITLE
Pass down args to bootstrap

### DIFF
--- a/yadm
+++ b/yadm
@@ -754,7 +754,7 @@ function bootstrap() {
   unset GIT_DIR
 
   echo "Executing $YADM_BOOTSTRAP"
-  exec "$YADM_BOOTSTRAP"
+  exec "$YADM_BOOTSTRAP" "$@"
 
 }
 


### PR DESCRIPTION
### What does this PR do?
Adds supports for args when yadm executes boostrap

E.g. :
`yadm bootstrap arg1 arg2 arg3`

### What issues does this PR fix or reference?

<!--
Be sure to preface the issue/PR numbers with a "#".
-->
[A list of related issues / pull requests.]

### Previous Behavior
yadm ignores args when executes bootstrap

### New Behavior
yadm pass args down to bootstrap if it was called manually

### Have [tests][1] been written for this change?
No

### Have these commits been [signed with GnuPG][2]?
 Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
