### PR TITLE
Add  example of bootstrap that can be used to run other scripts

### DIFF
--- a/contrib/bootstrap/bootstrap-source
+++ b/contrib/bootstrap/bootstrap-source
@@ -1,17 +1,17 @@
 #!/bin/bash
 
 # Save this file as ~/.config/yadm/bootstrap and make it executable. It expects
-# environment variable `source` with a name of shell script to execute.
-# `source` can be relative to ~/.config/yadm/ or full path.
+# environment variable `file` with a name of shell script to execute.
+# `file` can be relative to ~/.config/yadm/ or has full path.
 #
 #  Usage:
-#	source=install yadm bootstrap
+#    file=install yadm bootstrap
 #  or
-#	source=~/.config/yadm/install yadm bootstrap
+#    file=~/.config/yadm/install yadm bootstrap
 #
 # where `~/.config/yadm/install` can be like this:
 #
-# [[ ! $(type -t install) = 'function' ]] && echo "Usage: source=$(basename "$0") yadm bootstrap" && exit 1
+# [[ ! $(type -t install) = 'function' ]] && echo "Usage: file=$(basename "$0") yadm bootstrap" && exit 1
 #
 # confirm yes 'softwareupdate --agree-to-license --install --all' "$(info 'Install ' warning 'OSX updates')"
 # install 'brew' '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
@@ -42,7 +42,12 @@ warning() {
 }
 
 source_if_exists() {
-	if [[ -f $1 ]]; then source "$1"; else return 1; fi
+	local src=$1
+	local verbose="${2:-no}"
+
+	[[ ! -f $src ]] && return 1;
+	[[ "${verbose:0:1}" == v* ]] && printf "%s\n\n" "$(info "-> $src")";
+	source "$src"
 }
 
 command_exists () {
@@ -84,6 +89,6 @@ confirm() {
 	fi
 }
 
-source_if_exists "$(dirname "${0}")/$source" ||
-source_if_exists $source ||
-([[ -z $source ]] && echo "Usage: source=FILE yadm bootstrap" || echo "Can't locate file '$source' for bootstrapping")
+source_if_exists "$(dirname "${0}")/$file" v ||
+source_if_exists $file v ||
+([[ -z $file ]] && echo "Usage: file=FILENAME yadm bootstrap" || echo "Can't locate file '$file' for bootstrapping")

--- a/contrib/bootstrap/bootstrap-source
+++ b/contrib/bootstrap/bootstrap-source
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Save this file as ~/.config/yadm/bootstrap and make it executable. It expects
+# environment variable `source` with a name of shell script to execute.
+# `source` can be relative to ~/.config/yadm/ or full path.
+#
+#  Usage:
+#   source=install yadm bootstrap
+#  or
+#   source=~/.config/yadm/install yadm bootstrap
+#
+# where `~/.config/yadm/install` can be like this:
+#
+# [[ ! $(type -t install) = 'function' ]] && echo "Usage: source=$(basename "$0") yadm bootstrap" && exit 1
+#
+# confirm yes 'softwareupdate --agree-to-license --install --all' "$(info 'Install ' warning 'OSX updates')"
+# install 'brew' '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
+#
+# brew bundle --global
+#
+
+TEXT_COLOR_RED=$(tput setaf 1)
+TEXT_COLOR_GREEN=$(tput setaf 2)
+TEXT_COLOR_BLUE=$(tput setaf 4)
+TEXT_COLOR_YELLOW=$(tput setaf 3)
+TEXT_DEFAULT=$(tput sgr0)
+
+info() {
+    printf "${TEXT_COLOR_BLUE}%s${TEXT_DEFAULT}" "$1"; "${@:2}"
+}
+
+error() {
+    printf "${TEXT_COLOR_RED}%s${TEXT_DEFAULT}" "$1"; "${@:2}"
+}
+
+success() {
+    printf "${TEXT_COLOR_GREEN}%s${TEXT_DEFAULT}" "$1"; "${@:2}"
+}
+
+warning() {
+    printf "${TEXT_COLOR_YELLOW}%s${TEXT_DEFAULT}" "$1"; "${@:2}"
+}
+
+source_if_exists() {
+    if [[ -f $1 ]]; then source "$1"; else return 1; fi
+}
+
+command_exists () {
+    command -v "$1" &> /dev/null
+}
+
+# install a 'command' via 'code' if it was not previously installed yet
+install() {
+	local command=$1
+	local code=$2
+	local message=$(info 'Installing ' warning "$command")
+
+	if command_exists "$command"; then
+		echo "$message...[$(success 'already')]"
+	else
+		echo "$message..."
+		eval "$code"
+	fi
+}
+
+# execute a 'code' after confirmation from user
+confirm() {
+	local default_answer="${1:-no}"
+	local code=$2
+	local message=$3
+  local options answer
+
+	if [[ "${default_answer:0:1}" == y* ]]; then
+        options="$(success 'YES')/no"
+    else
+        options="yes/$(success 'NO')"
+    fi
+
+	read -r -p "${message} [${options}]:" answer
+	answer=${answer:-$default_answer}
+
+	if [[ "${answer:0:1}" == y* ]]; then
+		eval "$code"
+	fi
+}
+
+source_if_exists "$(dirname "${0}")/$source" ||
+source_if_exists $source ||
+([[ -z $source ]] && echo "Usage: source=FILE yadm bootstrap" || echo "Can't locate file '$source' for bootstrapping")

--- a/contrib/bootstrap/bootstrap-source
+++ b/contrib/bootstrap/bootstrap-source
@@ -5,9 +5,9 @@
 # `source` can be relative to ~/.config/yadm/ or full path.
 #
 #  Usage:
-#   source=install yadm bootstrap
+#	source=install yadm bootstrap
 #  or
-#   source=~/.config/yadm/install yadm bootstrap
+#	source=~/.config/yadm/install yadm bootstrap
 #
 # where `~/.config/yadm/install` can be like this:
 #
@@ -26,27 +26,27 @@ TEXT_COLOR_YELLOW=$(tput setaf 3)
 TEXT_DEFAULT=$(tput sgr0)
 
 info() {
-    printf "${TEXT_COLOR_BLUE}%s${TEXT_DEFAULT}" "$1"; "${@:2}"
+	printf "${TEXT_COLOR_BLUE}%s${TEXT_DEFAULT}" "$1"; "${@:2}"
 }
 
 error() {
-    printf "${TEXT_COLOR_RED}%s${TEXT_DEFAULT}" "$1"; "${@:2}"
+	printf "${TEXT_COLOR_RED}%s${TEXT_DEFAULT}" "$1"; "${@:2}"
 }
 
 success() {
-    printf "${TEXT_COLOR_GREEN}%s${TEXT_DEFAULT}" "$1"; "${@:2}"
+	printf "${TEXT_COLOR_GREEN}%s${TEXT_DEFAULT}" "$1"; "${@:2}"
 }
 
 warning() {
-    printf "${TEXT_COLOR_YELLOW}%s${TEXT_DEFAULT}" "$1"; "${@:2}"
+	printf "${TEXT_COLOR_YELLOW}%s${TEXT_DEFAULT}" "$1"; "${@:2}"
 }
 
 source_if_exists() {
-    if [[ -f $1 ]]; then source "$1"; else return 1; fi
+	if [[ -f $1 ]]; then source "$1"; else return 1; fi
 }
 
 command_exists () {
-    command -v "$1" &> /dev/null
+	command -v "$1" &> /dev/null
 }
 
 # install a 'command' via 'code' if it was not previously installed yet
@@ -68,13 +68,13 @@ confirm() {
 	local default_answer="${1:-no}"
 	local code=$2
 	local message=$3
-  local options answer
+	local options answer
 
 	if [[ "${default_answer:0:1}" == y* ]]; then
-        options="$(success 'YES')/no"
-    else
-        options="yes/$(success 'NO')"
-    fi
+		options="$(success 'YES')/no"
+	else
+		options="yes/$(success 'NO')"
+	fi
 
 	read -r -p "${message} [${options}]:" answer
 	answer=${answer:-$default_answer}


### PR DESCRIPTION
### What does this PR do?

Save this file as `~/.config/yadm/bootstrap` and make it executable. It expects
environment variable `file` with a name of shell script to execute.  `file` can be relative to ~/.config/yadm/ or has full 
path. 

It also adds some helpers (e.g. `install`, `confirm`, `command_exists`, `source_if_exists` ) that can be used in sourced files.

Usage:
``` 
file=install yadm bootstrap
```
or
```
file=~/.config/yadm/install yadm bootstrap
```

where `~/.config/yadm/install` can be like this:

```bash
[[ ! $(type -t install) = 'function' ]] && echo "Usage: file=$(basename "$0") yadm bootstrap" && exit 1

confirm yes 'softwareupdate --agree-to-license --install --all' "$(info 'Install ' warning 'OSX updates')"
install 'brew' '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'

brew bundle --global
```

### What issues does this PR fix or reference?

[A list of related issues / pull requests.]

### Previous Behavior

### New Behavior

### Have [tests][1] been written for this change?
No

### Have these commits been [signed with GnuPG][2]?
Yes

---
Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
