### PR TITLE
fix(clone): reset index of YADM_WORK

### DIFF
--- a/yadm
+++ b/yadm
@@ -827,7 +827,7 @@ function clone() {
   rm -rf "$wc"
 
   # then reset the index as the --no-checkout flag makes the index empty
-  "$GIT_PROGRAM" reset --quiet -- .
+  "$GIT_PROGRAM" reset --quiet -- "$YADM_WORK"
 
   if [ "$YADM_WORK" = "$HOME" ]; then
     debug "Determining if repo tracks private directories"


### PR DESCRIPTION
### What does this PR do?

Whenever using `clone` command inside YADM_WORK sub-directory, we need
to checkout the correct repo contents.

Steps to reproduce:

```bash
mkdir $HOME/subdir
cd $HOME/subdir

yadm clone --bootstrap "<repo-url>"
yadm status
```

### What issues does this PR fix or reference?

<!--
Be sure to preface the issue/PR numbers with a "#".
-->
[A list of related issues / pull requests.]

### Previous Behavior

`yadm status` reported a lot of deleted files.

### New Behavior

`yadm status` will report clean working directory.

### Have [tests][1] been written for this change?

Yes

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
