### PR TITLE
Support alt dirs with deeply nested tracked files

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -12,7 +12,7 @@ ALT_DIR = "test alt/test alt dir"
 
 # Directory based alternates must have a tracked contained file.
 # This will be the test contained file name
-CONTAINED = "contained_file"
+CONTAINED = "contained_dir/contained_file"
 
 # These variables are used for making include files which will be processed
 # within jinja templates

--- a/yadm
+++ b/yadm
@@ -461,7 +461,7 @@ EOF
     -v distro="$local_distro" \
     -v distro_family="$local_distro_family" \
     -v source="$input" \
-    -v source_dir="$(dirname "$input")" \
+    -v source_dir="$(builtin_dirname "$input")" \
     -v classes="$(join_string $'\n' "${local_classes[@]}")" \
     "$awk_pgm" \
     "$input" > "$temp_file" || rm -f "$temp_file"
@@ -692,9 +692,21 @@ function alt_linking() {
   local alt_sources=()
   local alt_template_cmds=()
 
-  for alt_path in $(for tracked in "${tracked_files[@]}"; do printf "%s\n" "$tracked" "${tracked%/*}"; done | LC_ALL=C sort -u) "${ENCRYPT_INCLUDE_FILES[@]}"; do
-    alt_path="$YADM_BASE/$alt_path"
-    if [[ "$alt_path" =~ .\#\#. ]]; then
+  for tracked_file in $(printf "%s\n" "${tracked_files[@]}" | LC_ALL=C sort -u) "${ENCRYPT_INCLUDE_FILES[@]}"; do
+    tracked_file="$YADM_BASE/$tracked_file"
+    if [[ "$tracked_file" =~ .\#\#. ]]; then
+      local alt_path=$tracked_file
+
+      # Walk up the path until we find the last component with a ## marker;
+      # that will be the source of the alt symlink
+      while : ; do
+        local tmp;
+        tmp="$(builtin_dirname "$alt_path")"
+        [[ "$tmp" =~ .\#\#. ]] || break
+        alt_path=$tmp
+      done
+
+      debug "Found alt at '$alt_path'"
       if [ -e "$alt_path" ] ; then
         score_file "$alt_path"
       fi

--- a/yadm.1
+++ b/yadm.1
@@ -595,7 +595,7 @@ If no "##default" version exists and no files have valid conditions, then no
 link will be created.
 
 Links are also created for directories named this way, as long as they have at
-least one yadm managed file within them (at the top level).
+least one yadm managed file as a descendant.
 
 yadm will automatically create these links by default. This can be disabled
 using the

--- a/yadm.md
+++ b/yadm.md
@@ -488,7 +488,7 @@
        then no link will be created.
 
        Links  are also created for directories named this way, as long as they
-       have at least one yadm managed file within them (at the top level).
+       have at least one yadm managed file as a descendant.
 
        yadm will automatically create these links by default. This can be dis‐
        abled  using  the yadm.auto-alt configuration.  Even if disabled, links


### PR DESCRIPTION
### What does this PR do?

Now, as long as there is a tracked file *somewhere* under the alt directory, it will be linked correctly, instead of requiring the tracked files to be direct children of the alt dir (previous behavior).

### What issues does this PR fix or reference?
Closes #490 
Related: #328, #356

### Previous Behavior

A tracked file had to be a direct child of the `##` alt directory for linking the directory to work properly.

### New Behavior

Any descendant of the `##` alt directory will cause it to be treated as an alt, and the directory itself will be linked (same as previous behavior).

### Have [tests][1] been written for this change?

Yes: Updated `test_alt` to use a subdirectory for its contained file as part of the tests. Verified the test failed before my changes and passes after.

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/TheLocehiliosan/yadm/blob/master/.github/CONTRIBUTING.md
