### PR TITLE
YADM_WORK: allow for relative worktree paths

### DIFF
--- a/test/test_alt.py
+++ b/test/test_alt.py
@@ -56,9 +56,13 @@ def test_alt_source(runner, paths, tracked, encrypt, exclude, yadm_alt):
 
 @pytest.mark.usefixtures("ds1_copy")
 @pytest.mark.parametrize("yadm_alt", [True, False], ids=["alt", "worktree"])
-def test_relative_link(runner, paths, yadm_alt):
+@pytest.mark.parametrize("rel_worktree", [True, False], ids=["relative_work", "absolute_work"])
+def test_relative_link(runner, paths, yadm_alt, yadm_cmd, rel_worktree):
     """Confirm links created are relative"""
     yadm_dir, yadm_data = setup_standard_yadm_dir(paths)
+
+    if rel_worktree:
+        runner(yadm_cmd("gitconfig", "core.worktree", "../../../.."))
 
     utils.create_alt_files(
         paths, "##default", tracked=True, encrypt=False, exclude=False, yadm_alt=yadm_alt, yadm_dir=yadm_dir

--- a/yadm
+++ b/yadm
@@ -1793,7 +1793,12 @@ function configure_paths() {
   # obtain YADM_WORK from repo if it exists
   if [ -d "$GIT_DIR" ]; then
     local work
+    # It's possible this is a relative path, in which case it's relative to $GIT_DIR:
+    # https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreworktree
     work=$(unix_path "$("$GIT_PROGRAM" config core.worktree)")
+    if [[ "$work" != /* ]]; then
+      work="$(cd "$GIT_DIR/$work" && pwd)"
+    fi
     [ -n "$work" ] && YADM_WORK="$work"
   fi
 


### PR DESCRIPTION
### What does this PR do?

Support relative paths in the yadm repo's `core.worktree`.

### What issues does this PR fix or reference?

<!--
Be sure to preface the issue/PR numbers with a "#".
-->
Relates to #414

I ran into an issue when trying to reference the git dir across filesystem boundaries (for example, in WSL). An absolute worktree directory results in "invalid" file paths (i.e. nonexistent) when Windows reads the Linux absolute path, or vice versa. 

I realize this is a pretty niche behavior but the change to make it work is fairly small, so I thought I'd submit a PR.

### Previous Behavior

`YADM_WORK` is set to the value of `core.worktree` directly.

### New Behavior

If it does not begin with `/`, the value of `core.worktree` is resolved to an absolute path relative to `GIT_DIR`.

This allows for a worktree path like `../../../..` which works across multiple platforms, allowing e.g. a Windows Git-bash clien to set a WSL yadm repo as a remote.

### Have [tests][1] been written for this change?

Yes

### Have these commits been [signed with GnuPG][2]?

Yes

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/yadm-dev/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/yadm-dev/yadm/blob/master/.github/CONTRIBUTING.md
