### PR TITLE
nfr 'yadm bootstrap' support arguments

### DIFF
--- a/yadm
+++ b/yadm
@@ -752,7 +752,7 @@ function bootstrap() {
   unset GIT_DIR
 
   echo "Executing $YADM_BOOTSTRAP"
-  exec "$YADM_BOOTSTRAP"
+  exec "$YADM_BOOTSTRAP"  $@
 
 }
 


### PR DESCRIPTION
### What does this PR do?

Let 'yadm bootstrap' support arguments.

### What issues does this PR fix or reference?
Above.

### Previous Behavior
`the bootstrap` can't support behaviour specified by arguments, like:
yadm bootstrap --config-only

### New Behavior
```bash
# Only config
yadm bootstrap --config-only
```

### Have [tests][1] been written for this change?
No

### Have these commits been [signed with GnuPG][2]?
No

---

Please review [yadm's Contributing Guide][3] for best practices.

[1]: https://github.com/yadm-dev/yadm/blob/master/.github/CONTRIBUTING.md#test-conventions
[2]: https://help.github.com/en/articles/signing-commits
[3]: https://github.com/yadm-dev/yadm/blob/master/.github/CONTRIBUTING.md
