### PR TITLE
Only update files if work-tree changes

### DIFF
--- a/test/test_alt.py
+++ b/test/test_alt.py
@@ -248,7 +248,7 @@ def test_auto_alt(runner, yadm_cmd, paths, autoalt):
         os.system(" ".join(yadm_cmd("config", "yadm.auto-alt", autoalt)))
 
     utils.create_alt_files(paths, "##default")
-    run = runner(yadm_cmd("status"))
+    run = runner(yadm_cmd("reset"))
     assert run.success
     assert run.err == ""
     linked = utils.parse_alt_output(run.out)

--- a/test/test_assert_private_dirs.py
+++ b/test/test_assert_private_dirs.py
@@ -29,11 +29,10 @@ def test_pdirs_missing(runner, yadm_cmd, paths, home):
     if home:
         env["HOME"] = paths.work
 
-    # run status
-    run = runner(command=yadm_cmd("status"), env=env)
+    # run reset
+    run = runner(command=yadm_cmd("reset"), env=env)
     assert run.success
     assert run.err == ""
-    assert "On branch master" in run.out
 
     # confirm directories are created
     # and are protected
@@ -48,7 +47,7 @@ def test_pdirs_missing(runner, yadm_cmd, paths, home):
     # confirm directories are created before command is run:
     if home:
         assert re.search(
-            r"Creating.+\.(gnupg|ssh).+Creating.+\.(gnupg|ssh).+Running git command git status", run.out, re.DOTALL
+            r"Creating.+\.(gnupg|ssh).+Creating.+\.(gnupg|ssh).+Running git command git reset", run.out, re.DOTALL
         ), "directories created before command is run"
 
 
@@ -71,11 +70,11 @@ def test_pdirs_missing_apd_false(runner, yadm_cmd, paths):
     # set configuration
     os.system(" ".join(yadm_cmd("config", "--bool", "yadm.auto-private-dirs", "false")))
 
-    # run status
-    run = runner(command=yadm_cmd("status"))
+    # run reset
+    run = runner(command=yadm_cmd("reset"))
     assert run.success
     assert run.err == ""
-    assert "On branch master" in run.out
+    assert run.out == ""
 
     # confirm directories are STILL missing
     for pdir in PRIVATE_DIRS:
@@ -102,11 +101,11 @@ def test_pdirs_exist_apd_false(runner, yadm_cmd, paths):
     # set configuration
     os.system(" ".join(yadm_cmd("config", "--bool", "yadm.auto-perms", "false")))
 
-    # run status
-    run = runner(command=yadm_cmd("status"))
+    # run reset
+    run = runner(command=yadm_cmd("reset"))
     assert run.success
     assert run.err == ""
-    assert "On branch master" in run.out
+    assert run.out == ""
 
     # created directories are STILL permissive
     for pdir in PRIVATE_DIRS:

--- a/test/test_perms.py
+++ b/test/test_perms.py
@@ -37,7 +37,7 @@ def test_perms(runner, yadm_cmd, paths, ds1, autoperms):
 
     cmd = "perms"
     if autoperms != "notest":
-        cmd = "status"
+        cmd = "reset"
     run = runner(yadm_cmd(cmd), env={"HOME": paths.work})
     assert run.success
     assert run.err == ""

--- a/yadm
+++ b/yadm
@@ -1143,18 +1143,23 @@ function git_command() {
   fi
 
   # ensure private .ssh and .gnupg directories exist first
-  # TODO: consider restricting this to only commands which modify the work-tree
+   declare -A non_modify
+  for nm_command in bisect blame bugreport cat-file check-attr check-ignore check-mailmap check-ref-format cherry column count-objects cvsexportcommit csvserver daemon describe diff-files diff-index diff difftool diff-tree fast-export fetch for-each-ref fsck get-tar-commit-id grep hash-object help http-backend http-fetch http-push imap-send instaweb log ls-files ls-remote ls-tree mailinfo name-rev push range-diff reflog remote request-pull rev-list rev-parse send-mail send-pack shortlog show-branch show-index show-ref show status var verify-commit verify-pack version whatchanged; do
+    non_modify["$nm_command"]=1
+  done
 
-  if [ "$YADM_WORK" = "$HOME" ]; then
-    auto_private_dirs=$(config --bool yadm.auto-private-dirs)
-    if [ "$auto_private_dirs" != "false" ]; then
-      for pdir in $(private_dirs all); do
-        assert_private_dirs "$pdir"
-      done
+  if [ -z "${non_modify["$1"]}" ]; then
+    if [ "$YADM_WORK" = "$HOME" ]; then
+      auto_private_dirs=$(config --bool yadm.auto-private-dirs)
+      if [ "$auto_private_dirs" != "false" ]; then
+        for pdir in $(private_dirs all); do
+          assert_private_dirs "$pdir"
+        done
+      fi
     fi
-  fi
 
-  CHANGES_POSSIBLE=1
+    CHANGES_POSSIBLE=1
+  fi
 
   # pass commands through to git
   debug "Running git command $GIT_PROGRAM $*"


### PR DESCRIPTION
Git commands that don't modify the work tree don't trigger yadm updates
E.g. running `yadm status` doesn't update any alt files

### What does this PR do?

My alt files got reloaded with every git command. So I searched for the reason and found the open TODO and tried to fix it.
I'm not perfectly familiar with bash syntax, so I'll happily implement any suggetions :)

### What issues does this PR fix or reference?

#355 

### Previous Behavior

Every time you did any git command (e.g. git status) all of the alt files got reloaded

### New Behavior

Only git commands that change the work tree reload any files.

### Have [tests][1] been written for this change?

No

### Have these commits been [signed with GnuPG][2]?

Yes
